### PR TITLE
공통 ResponseDto 추가, ResponseErrorDto 추가, ResponseDto Test 추가

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -34,6 +34,8 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
+	testImplementation 'org.projectlombok:lombok'
+	testAnnotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 

--- a/server/src/main/java/ppalatjyo/server/global/RestDocTestController.java
+++ b/server/src/main/java/ppalatjyo/server/global/RestDocTestController.java
@@ -1,4 +1,4 @@
-package ppalatjyo.server.common;
+package ppalatjyo.server.global;
 
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;

--- a/server/src/main/java/ppalatjyo/server/global/audit/AuditConfig.java
+++ b/server/src/main/java/ppalatjyo/server/global/audit/AuditConfig.java
@@ -1,9 +1,9 @@
-package ppalatjyo.server.common;
+package ppalatjyo.server.global.audit;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @Configuration
 @EnableJpaAuditing
-public class ApplicationConfig {
+public class AuditConfig {
 }

--- a/server/src/main/java/ppalatjyo/server/global/audit/BaseEntity.java
+++ b/server/src/main/java/ppalatjyo/server/global/audit/BaseEntity.java
@@ -1,4 +1,4 @@
-package ppalatjyo.server.common;
+package ppalatjyo.server.global.audit;
 
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;

--- a/server/src/main/java/ppalatjyo/server/global/dto/ResponseDto.java
+++ b/server/src/main/java/ppalatjyo/server/global/dto/ResponseDto.java
@@ -1,0 +1,39 @@
+package ppalatjyo.server.global.dto;
+
+import lombok.*;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import ppalatjyo.server.global.dto.error.ResponseErrorDto;
+
+@Data
+@Builder
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ResponseDto<T> {
+    private boolean success;
+    private int status;
+    private String message;
+    private T data;
+    private ResponseErrorDto error;
+
+    public static <T> ResponseEntity<ResponseDto<T>> ok(String message, T data) {
+        ResponseDto<T> responseDto = ResponseDto.<T>builder()
+                .success(true)
+                .status(HttpStatus.OK.value())
+                .message(message)
+                .data(data)
+                .build();
+
+        return ResponseEntity.ok(responseDto);
+    }
+
+    public static ResponseEntity<ResponseDto<Void>> ok(String message) {
+        ResponseDto<Void> dto = ResponseDto.<Void>builder()
+                .success(true)
+                .status(HttpStatus.OK.value())
+                .message(message)
+                .build();
+
+        return ResponseEntity.ok(dto);
+    }
+}

--- a/server/src/main/java/ppalatjyo/server/global/dto/ResponseMessage.java
+++ b/server/src/main/java/ppalatjyo/server/global/dto/ResponseMessage.java
@@ -1,0 +1,9 @@
+package ppalatjyo.server.global.dto;
+
+public enum ResponseMessage {
+    SUCCESS;
+
+    public String getMessage() {
+        return "";
+    }
+}

--- a/server/src/main/java/ppalatjyo/server/global/dto/ResponseTestController.java
+++ b/server/src/main/java/ppalatjyo/server/global/dto/ResponseTestController.java
@@ -1,0 +1,14 @@
+package ppalatjyo.server.global.dto;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class ResponseTestController {
+
+    @GetMapping("/test/ok")
+    public ResponseEntity<ResponseDto<Void>> testOk() {
+        return ResponseDto.ok("ok.");
+    }
+}

--- a/server/src/main/java/ppalatjyo/server/global/dto/error/ErrorType.java
+++ b/server/src/main/java/ppalatjyo/server/global/dto/error/ErrorType.java
@@ -1,0 +1,4 @@
+package ppalatjyo.server.global.dto.error;
+
+public enum ErrorType {
+}

--- a/server/src/main/java/ppalatjyo/server/global/dto/error/FieldErrorDto.java
+++ b/server/src/main/java/ppalatjyo/server/global/dto/error/FieldErrorDto.java
@@ -1,0 +1,9 @@
+package ppalatjyo.server.global.dto.error;
+
+import lombok.Data;
+
+@Data
+public class FieldErrorDto {
+    private Object rejectedValue;
+    private String message;
+}

--- a/server/src/main/java/ppalatjyo/server/global/dto/error/ResponseErrorDto.java
+++ b/server/src/main/java/ppalatjyo/server/global/dto/error/ResponseErrorDto.java
@@ -1,0 +1,15 @@
+package ppalatjyo.server.global.dto.error;
+
+import lombok.Data;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+@Data
+public class ResponseErrorDto {
+    private ErrorType type;
+    private String message;
+    private String path;
+    private LocalDateTime timestamp;
+    private Map<String, FieldErrorDto> data;
+}

--- a/server/src/main/java/ppalatjyo/server/lobby/domain/Lobby.java
+++ b/server/src/main/java/ppalatjyo/server/lobby/domain/Lobby.java
@@ -2,7 +2,7 @@ package ppalatjyo.server.lobby.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
-import ppalatjyo.server.common.BaseEntity;
+import ppalatjyo.server.global.audit.BaseEntity;
 import ppalatjyo.server.lobby.LobbyAlreadyDeletedException;
 import ppalatjyo.server.quiz.domain.Quiz;
 import ppalatjyo.server.user.domain.User;

--- a/server/src/main/java/ppalatjyo/server/quiz/domain/Quiz.java
+++ b/server/src/main/java/ppalatjyo/server/quiz/domain/Quiz.java
@@ -2,7 +2,7 @@ package ppalatjyo.server.quiz.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
-import ppalatjyo.server.common.BaseEntity;
+import ppalatjyo.server.global.audit.BaseEntity;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/server/src/main/java/ppalatjyo/server/user/domain/User.java
+++ b/server/src/main/java/ppalatjyo/server/user/domain/User.java
@@ -2,7 +2,7 @@ package ppalatjyo.server.user.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
-import ppalatjyo.server.common.BaseEntity;
+import ppalatjyo.server.global.audit.BaseEntity;
 import ppalatjyo.server.user.UserAlreadyMemberException;
 
 import java.time.LocalDateTime;

--- a/server/src/test/java/ppalatjyo/server/global/RestDocTestControllerTest.java
+++ b/server/src/test/java/ppalatjyo/server/global/RestDocTestControllerTest.java
@@ -1,4 +1,4 @@
-package ppalatjyo.server.common;
+package ppalatjyo.server.global;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -7,7 +7,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.web.servlet.MockMvc;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;

--- a/server/src/test/java/ppalatjyo/server/global/dto/ResponseDtoTest.java
+++ b/server/src/test/java/ppalatjyo/server/global/dto/ResponseDtoTest.java
@@ -1,0 +1,65 @@
+package ppalatjyo.server.global.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ResponseDtoTest {
+
+    @Test
+    @DisplayName("성공 응답 - 메시지")
+    void okWithMessage() {
+        // given
+        String message = "Okay.";
+
+        // when
+        ResponseEntity<ResponseDto<Void>> response = ResponseDto.ok(message);
+
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody()).isInstanceOf(ResponseDto.class);
+        assertThat(response.getBody().isSuccess()).isTrue();
+        assertThat(response.getBody().getStatus()).isEqualTo(HttpStatus.OK.value());
+        assertThat(response.getBody().getMessage()).isEqualTo(message);
+        assertThat(response.getBody().getData()).isNull();
+        assertThat(response.getBody().getError()).isNull();
+    }
+
+    @Test
+    @DisplayName("성공 응답 - 메시지 + 데이터")
+    void okWithMessageAndData() {
+        // given
+        String message = "Okay with data.";
+        String content = "content";
+        TestResponseDto dataDto = new TestResponseDto(content);
+
+        // when
+        ResponseEntity<ResponseDto<TestResponseDto>> response = ResponseDto.ok(message, dataDto);
+
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody()).isInstanceOf(ResponseDto.class);
+        assertThat(response.getBody().isSuccess()).isTrue();
+        assertThat(response.getBody().getStatus()).isEqualTo(HttpStatus.OK.value());
+        assertThat(response.getBody().getMessage()).isEqualTo(message);
+        assertThat(response.getBody().getError()).isNull();
+
+        assertThat(response.getBody().getData()).isNotNull();
+        assertThat(response.getBody().getData()).isInstanceOf(TestResponseDto.class);
+        assertThat(response.getBody().getData().getContent()).isEqualTo(content);
+    }
+
+    @Data
+    @AllArgsConstructor
+    static
+    class TestResponseDto {
+        private String content;
+    }
+}


### PR DESCRIPTION
## 변경 사항

- 공통 ResponseDto를 추가하였습니다.
- ResponseDto 내에 ResponseEntity를 반환하도록 정적 펙토리 메서드를 구현하였습니다.
- ResponseDto 는 제네릭 타입으로 내부 data 필드에 들어갈 Dto를 매개변수로 받도록 구현하였습니다. (상속이 아님 -> final 조치?)
- error 필드 공통화를 위해 ResponseErrorDto 클래스를 추가하였습니다.
  - ResponseErrorDto는 디버깅을 위한 각종 필드를 제공합니다.
  - ResponseErrorDto는 Validation 시에 각 필드에 대한 reject된 값과 에러 메시지를 제공하는 FieldErrorDto의 Map을 data 필드로 가집니다.
  - ErrorType은 현재 비어있습니다.
- `common` 패키지 이름을 `global`로 변경하였습니다.
- 공통 DTO 관련 클래스를 `/global/dto`에 생성하였습니다.
- Audit 관련 클래스를 `/global/audit`으로 이동하였습니다.

## 스크린샷

<img width="1070" alt="image" src="https://github.com/user-attachments/assets/effcfacc-73c4-4c36-b1bb-c08759147685" />

## 고려 사항

- ResponseDto는 성공 응답에 대해서만 테스트를 작성하였습니다. 
- 차후 필요에 따라 메서드 및 테스트를 추가합니다.
- 에러 메시지 이외 에러 타입이 따로 필요한지 의문입니다. 
  - 각 에러를 발생시킨 예외 이름을 에러 메시지로 정의하면 좋을지..?