### PR TITLE
BaseEntity -> BaseEntity (extends) BaseTimeEntity 로 수정

### DIFF
--- a/server/src/main/java/ppalatjyo/server/global/audit/AuditConfig.java
+++ b/server/src/main/java/ppalatjyo/server/global/audit/AuditConfig.java
@@ -1,6 +1,8 @@
 package ppalatjyo.server.global.audit;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.AuditorAware;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @Configuration

--- a/server/src/main/java/ppalatjyo/server/global/audit/AuditorAwareImpl.java
+++ b/server/src/main/java/ppalatjyo/server/global/audit/AuditorAwareImpl.java
@@ -1,0 +1,30 @@
+package ppalatjyo.server.global.audit;
+
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import ppalatjyo.server.global.security.userdetails.CustomUserDetails;
+
+import java.util.Optional;
+
+@Component
+public class AuditorAwareImpl implements AuditorAware<String> {
+
+    @Override
+    public Optional<String> getCurrentAuditor() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return Optional.of("system"); // fallback
+        }
+
+        Object principal = authentication.getPrincipal();
+
+        if (principal instanceof CustomUserDetails userDetails) {
+            return Optional.of("user-" + userDetails.getId());
+        }
+
+        return Optional.of("system");
+    }
+}

--- a/server/src/main/java/ppalatjyo/server/global/audit/BaseTimeEntity.java
+++ b/server/src/main/java/ppalatjyo/server/global/audit/BaseTimeEntity.java
@@ -4,9 +4,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
-import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedBy;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -15,14 +13,12 @@ import java.time.LocalDateTime;
 @Getter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
-public class BaseEntity extends BaseTimeEntity {
-
-    @CreatedBy
+public class BaseTimeEntity {
+    @CreatedDate
     @Column(nullable = false, updatable = false)
-    private String createdBy;
+    private LocalDateTime createdAt;
 
-    @LastModifiedBy
+    @LastModifiedDate
     @Column(nullable = false)
-    private String lastModifiedBy;
-
+    private LocalDateTime lastModifiedAt;
 }

--- a/server/src/main/java/ppalatjyo/server/global/security/userdetails/CustomUserDetails.java
+++ b/server/src/main/java/ppalatjyo/server/global/security/userdetails/CustomUserDetails.java
@@ -8,11 +8,11 @@ import ppalatjyo.server.user.domain.UserRole;
 import java.util.Collection;
 import java.util.List;
 
-public class CustomUserDetail implements UserDetails {
+public class CustomUserDetails implements UserDetails {
 
     private final User user;
 
-    public CustomUserDetail(User user) {
+    public CustomUserDetails(User user) {
         this.user = user;
     }
 

--- a/server/src/main/java/ppalatjyo/server/global/security/userdetails/CustomUserDetailsService.java
+++ b/server/src/main/java/ppalatjyo/server/global/security/userdetails/CustomUserDetailsService.java
@@ -16,7 +16,7 @@ public class CustomUserDetailsService implements UserDetailsService {
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
         return userRepository.findById(Long.valueOf(username))
-                .map(CustomUserDetail::new)
+                .map(CustomUserDetails::new)
                 .orElseThrow(() -> new UsernameNotFoundException("User not found with username: " + username));
     }
 }


### PR DESCRIPTION
## 관련 이슈
- #20 

## 변경 사항
- BaseEntity -> BaseEntity (extends) BaseTimeEntity 로 수정
- AuditorAwareImpl 구현
- AuditorAwareImpl 의 getCurrentAuditor()에서
  - 현재 SecurityContext 내 authenticated된 유저가 있는 경우: `user-{userId}`
  - 그 외: `system`
  - 으로 createdby와 lastModifiedBy를 기록하도록 구현

## 고려 사항
- 유저가 아닌 경우 `system`으로 하는 것으로 충분한지 잘 모르겠습니다?
- Auditing의 목적에 대해 생각해볼 것
  - createdby, lastModifiedBy로 확인하고 하는 것?
  - 추후 admin 여부, server id, admin 식별자 등 넣는 것 고려