### PR TITLE
[Feature #14]: 도메인 구현

### DIFF
--- a/server/src/main/java/ppalatjyo/server/game/Game.java
+++ b/server/src/main/java/ppalatjyo/server/game/Game.java
@@ -6,7 +6,6 @@ import lombok.*;
 import ppalatjyo.server.game.exception.GameAlreadyEndedException;
 import ppalatjyo.server.global.audit.BaseEntity;
 import ppalatjyo.server.lobby.domain.Lobby;
-import ppalatjyo.server.lobby.domain.LobbyOptions;
 import ppalatjyo.server.quiz.domain.Question;
 import ppalatjyo.server.quiz.domain.Quiz;
 

--- a/server/src/main/java/ppalatjyo/server/game/Game.java
+++ b/server/src/main/java/ppalatjyo/server/game/Game.java
@@ -1,0 +1,71 @@
+package ppalatjyo.server.game;
+
+
+import jakarta.persistence.*;
+import lombok.*;
+import ppalatjyo.server.global.audit.BaseEntity;
+import ppalatjyo.server.lobby.domain.Lobby;
+import ppalatjyo.server.quiz.domain.Question;
+import ppalatjyo.server.quiz.domain.Quiz;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+public class Game extends BaseEntity {
+    @Id
+    @GeneratedValue
+    @Column(name = "game_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "lobby_id")
+    private Lobby lobby;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "quiz_id")
+    private Quiz quiz;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "current_question_id")
+    private Question currentQuestion;
+
+    private int currentQuestionIndex;
+
+    private LocalDateTime startedAt;
+    private LocalDateTime endedAt;
+
+    public static Game start(Lobby lobby) {
+        return Game.builder()
+                .lobby(lobby)
+                .quiz(lobby.getQuiz())
+                .currentQuestion(lobby.getQuiz().getQuestions().getFirst())
+                .currentQuestionIndex(0)
+                .startedAt(LocalDateTime.now())
+                .build();
+    }
+
+    public void end() {
+        endedAt = LocalDateTime.now();
+    }
+
+    public boolean isEnded() {
+        return endedAt != null;
+    }
+
+    public boolean hasNextQuestion() {
+        return quiz.getQuestions().size() > 1 && currentQuestionIndex < quiz.getQuestions().size() - 1;
+    }
+
+    public void nextQuestion() {
+        if (!hasNextQuestion()) {
+            end();
+            return;
+        }
+
+        currentQuestion = quiz.getQuestions().get(++currentQuestionIndex);
+    }
+}

--- a/server/src/main/java/ppalatjyo/server/game/Game.java
+++ b/server/src/main/java/ppalatjyo/server/game/Game.java
@@ -3,8 +3,10 @@ package ppalatjyo.server.game;
 
 import jakarta.persistence.*;
 import lombok.*;
+import ppalatjyo.server.game.exception.GameAlreadyEndedException;
 import ppalatjyo.server.global.audit.BaseEntity;
 import ppalatjyo.server.lobby.domain.Lobby;
+import ppalatjyo.server.lobby.domain.LobbyOptions;
 import ppalatjyo.server.quiz.domain.Question;
 import ppalatjyo.server.quiz.domain.Quiz;
 
@@ -38,6 +40,9 @@ public class Game extends BaseEntity {
     private LocalDateTime startedAt;
     private LocalDateTime endedAt;
 
+    @Embedded
+    private GameOptions options;
+
     public static Game start(Lobby lobby) {
         return Game.builder()
                 .lobby(lobby)
@@ -45,10 +50,15 @@ public class Game extends BaseEntity {
                 .currentQuestion(lobby.getQuiz().getQuestions().getFirst())
                 .currentQuestionIndex(0)
                 .startedAt(LocalDateTime.now())
+                .options(GameOptions.copy(lobby.getOptions()))
                 .build();
     }
 
     public void end() {
+        if (isEnded()) {
+            throw new GameAlreadyEndedException();
+        }
+
         endedAt = LocalDateTime.now();
     }
 

--- a/server/src/main/java/ppalatjyo/server/game/GameOptions.java
+++ b/server/src/main/java/ppalatjyo/server/game/GameOptions.java
@@ -1,0 +1,22 @@
+package ppalatjyo.server.game;
+
+import jakarta.persistence.Embeddable;
+import lombok.*;
+import ppalatjyo.server.lobby.domain.LobbyOptions;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@Embeddable
+public class GameOptions {
+    private int minPerGame;
+    private int secPerQuestion;
+
+    public static GameOptions copy(LobbyOptions options) {
+        return GameOptions.builder()
+                .minPerGame(options.getMinPerGame())
+                .secPerQuestion(options.getSecPerQuestion())
+                .build();
+    }
+}

--- a/server/src/main/java/ppalatjyo/server/game/NoNextQuestionException.java
+++ b/server/src/main/java/ppalatjyo/server/game/NoNextQuestionException.java
@@ -1,0 +1,7 @@
+package ppalatjyo.server.game;
+
+public class NoNextQuestionException extends RuntimeException {
+    public NoNextQuestionException() {
+        super("No more questions.");
+    }
+}

--- a/server/src/main/java/ppalatjyo/server/game/exception/GameAlreadyEndedException.java
+++ b/server/src/main/java/ppalatjyo/server/game/exception/GameAlreadyEndedException.java
@@ -1,0 +1,7 @@
+package ppalatjyo.server.game.exception;
+
+public class GameAlreadyEndedException extends RuntimeException {
+    public GameAlreadyEndedException() {
+        super("Game has already ended.");
+    }
+}

--- a/server/src/main/java/ppalatjyo/server/game/exception/NoNextQuestionException.java
+++ b/server/src/main/java/ppalatjyo/server/game/exception/NoNextQuestionException.java
@@ -1,4 +1,4 @@
-package ppalatjyo.server.game;
+package ppalatjyo.server.game.exception;
 
 public class NoNextQuestionException extends RuntimeException {
     public NoNextQuestionException() {

--- a/server/src/main/java/ppalatjyo/server/gameevent/GameEvent.java
+++ b/server/src/main/java/ppalatjyo/server/gameevent/GameEvent.java
@@ -1,0 +1,66 @@
+package ppalatjyo.server.gameevent;
+
+import jakarta.persistence.*;
+import lombok.*;
+import ppalatjyo.server.game.Game;
+import ppalatjyo.server.global.audit.BaseEntity;
+import ppalatjyo.server.message.Message;
+import ppalatjyo.server.usergame.UserGame;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+public class GameEvent extends BaseEntity {
+
+    @Id
+    @GeneratedValue
+    @Column(name = "game_event_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "game_id")
+    private Game game;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_game_id")
+    private UserGame userGame;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "message_id")
+    private Message message;
+
+    @Enumerated(EnumType.STRING)
+    private GameEventType type;
+
+
+    private static GameEvent create(Game game, UserGame userGame, Message message, GameEventType type) {
+        return GameEvent.builder()
+                .game(game)
+                .userGame(userGame)
+                .message(message)
+                .type(type)
+                .build();
+    }
+
+    public static GameEvent started(Game game, UserGame userGame) {
+        return create(game, userGame, null, GameEventType.GAME_STARTED);
+    }
+
+    public static GameEvent ended(Game game) {
+        return create(game, null, null, GameEventType.GAME_ENDED);
+    }
+
+    public static GameEvent wrongAnswer(Game game, UserGame userGame, Message message) {
+        return create(game, userGame, message, GameEventType.WRONG_ANSWER);
+    }
+
+    public static GameEvent rightAnswer(Game game, UserGame userGame, Message message) {
+        return create(game, userGame, message, GameEventType.RIGHT_ANSWER);
+    }
+
+    public static GameEvent timeOut(Game game) {
+        return create(game, null, null, GameEventType.TIME_OUT);
+    }
+}

--- a/server/src/main/java/ppalatjyo/server/gameevent/GameEventType.java
+++ b/server/src/main/java/ppalatjyo/server/gameevent/GameEventType.java
@@ -1,0 +1,5 @@
+package ppalatjyo.server.gameevent;
+
+public enum GameEventType {
+    GAME_STARTED, GAME_ENDED, WRONG_ANSWER, RIGHT_ANSWER, TIME_OUT
+}

--- a/server/src/main/java/ppalatjyo/server/lobby/LobbyService.java
+++ b/server/src/main/java/ppalatjyo/server/lobby/LobbyService.java
@@ -19,11 +19,11 @@ public class LobbyService {
     private UserRepository userRepository;
     private QuizRepository quizRepository;
 
-    public void createLobby(long hostId, long quizId, LobbyOptions options) {
+    public void createLobby(String name, long hostId, long quizId, LobbyOptions options) {
         User host = userRepository.findById(hostId).orElseThrow();
         Quiz quiz = quizRepository.findById(quizId).orElseThrow();
 
-        Lobby lobby = Lobby.createLobby(host, quiz, options);
+        Lobby lobby = Lobby.createLobby(name, host, quiz, options);
         lobbyRepository.save(lobby);
     }
 

--- a/server/src/main/java/ppalatjyo/server/lobby/domain/Lobby.java
+++ b/server/src/main/java/ppalatjyo/server/lobby/domain/Lobby.java
@@ -20,6 +20,8 @@ public class Lobby extends BaseEntity {
     @Column(name = "lobby_id")
     private Long id;
 
+    private String name;
+
     @Embedded
     private LobbyOptions options;
 
@@ -33,8 +35,9 @@ public class Lobby extends BaseEntity {
     @JoinColumn(name = "quiz_id")
     private Quiz quiz;
 
-    public static Lobby createLobby(User host, Quiz quiz, LobbyOptions options) {
+    public static Lobby createLobby(String name, User host, Quiz quiz, LobbyOptions options) {
         return Lobby.builder()
+                .name(name)
                 .host(host)
                 .quiz(quiz)
                 .options(options)

--- a/server/src/main/java/ppalatjyo/server/lobby/domain/Lobby.java
+++ b/server/src/main/java/ppalatjyo/server/lobby/domain/Lobby.java
@@ -63,4 +63,8 @@ public class Lobby extends BaseEntity {
     public void changeQuiz(Quiz quiz) {
         this.quiz = quiz;
     }
+
+    public void changeName(String name) {
+        this.name = name;
+    }
 }

--- a/server/src/main/java/ppalatjyo/server/lobby/domain/Lobby.java
+++ b/server/src/main/java/ppalatjyo/server/lobby/domain/Lobby.java
@@ -17,6 +17,7 @@ import java.time.LocalDateTime;
 public class Lobby extends BaseEntity {
 
     @Id @GeneratedValue
+    @Column(name = "lobby_id")
     private Long id;
 
     @Embedded

--- a/server/src/main/java/ppalatjyo/server/lobby/domain/LobbyOptions.java
+++ b/server/src/main/java/ppalatjyo/server/lobby/domain/LobbyOptions.java
@@ -13,11 +13,23 @@ public class LobbyOptions {
     private int minPerGame;
     private int secPerQuestion;
 
+    public static final int DEFAULT_MAX_USERS = 10;
+    public static final int DEFAULT_MIN_PER_GAME = 5;
+    public static final int DEFAULT_SEC_PER_QUESTION = 60;
+
     public static LobbyOptions createOptions(int maxUsers, int minPerGame, int secPerQuestion) {
         return LobbyOptions.builder()
                 .maxUsers(maxUsers)
                 .minPerGame(minPerGame)
                 .secPerQuestion(secPerQuestion)
+                .build();
+    }
+
+    public static LobbyOptions createDefaultOptions() {
+        return LobbyOptions.builder()
+                .maxUsers(DEFAULT_MAX_USERS)
+                .minPerGame(DEFAULT_MIN_PER_GAME)
+                .secPerQuestion(DEFAULT_SEC_PER_QUESTION)
                 .build();
     }
 }

--- a/server/src/main/java/ppalatjyo/server/lobby/domain/LobbyOptions.java
+++ b/server/src/main/java/ppalatjyo/server/lobby/domain/LobbyOptions.java
@@ -25,7 +25,7 @@ public class LobbyOptions {
                 .build();
     }
 
-    public static LobbyOptions createDefaultOptions() {
+    public static LobbyOptions defaultOptions() {
         return LobbyOptions.builder()
                 .maxUsers(DEFAULT_MAX_USERS)
                 .minPerGame(DEFAULT_MIN_PER_GAME)

--- a/server/src/main/java/ppalatjyo/server/message/Message.java
+++ b/server/src/main/java/ppalatjyo/server/message/Message.java
@@ -1,0 +1,50 @@
+package ppalatjyo.server.message;
+
+import jakarta.persistence.*;
+import lombok.*;
+import ppalatjyo.server.game.Game;
+import ppalatjyo.server.global.audit.BaseEntity;
+import ppalatjyo.server.lobby.domain.Lobby;
+import ppalatjyo.server.user.domain.User;
+
+import java.lang.reflect.Member;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+public class Message extends BaseEntity {
+
+    @Id
+    @GeneratedValue
+    @Column(name = "message_id")
+    private Long id;
+
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "lobby_id")
+    private Lobby lobby;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "game_id")
+    private Game game;
+
+    public static Message create(String content, User user, Lobby lobby) {
+        return create(content, user, lobby, null);
+    }
+
+    public static Message create(String content, User user, Lobby lobby, Game game) {
+        return Message.builder()
+                .content(content)
+                .user(user)
+                .lobby(lobby)
+                .game(game)
+                .build();
+    }
+}

--- a/server/src/main/java/ppalatjyo/server/quiz/GuestCannotCreateQuizException.java
+++ b/server/src/main/java/ppalatjyo/server/quiz/GuestCannotCreateQuizException.java
@@ -1,0 +1,7 @@
+package ppalatjyo.server.quiz;
+
+public class GuestCannotCreateQuizException extends RuntimeException {
+    public GuestCannotCreateQuizException() {
+        super("Guest cannot create quiz.");
+    }
+}

--- a/server/src/main/java/ppalatjyo/server/quiz/domain/Answer.java
+++ b/server/src/main/java/ppalatjyo/server/quiz/domain/Answer.java
@@ -2,13 +2,14 @@ package ppalatjyo.server.quiz.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
+import ppalatjyo.server.global.audit.BaseEntity;
 
 @Entity
 @Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
-public class Answer {
+public class Answer extends BaseEntity {
     @Id @GeneratedValue
     @Column(name = "answer_id")
     private Long id;

--- a/server/src/main/java/ppalatjyo/server/quiz/domain/Answer.java
+++ b/server/src/main/java/ppalatjyo/server/quiz/domain/Answer.java
@@ -10,6 +10,7 @@ import lombok.*;
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class Answer {
     @Id @GeneratedValue
+    @Column(name = "answer_id")
     private Long id;
     private String content;
 

--- a/server/src/main/java/ppalatjyo/server/quiz/domain/Question.java
+++ b/server/src/main/java/ppalatjyo/server/quiz/domain/Question.java
@@ -2,6 +2,7 @@ package ppalatjyo.server.quiz.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
+import ppalatjyo.server.global.audit.BaseEntity;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -11,7 +12,7 @@ import java.util.Set;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
-public class Question {
+public class Question extends BaseEntity {
     @Id @GeneratedValue
     @Column(name = "question_id")
     private Long id;

--- a/server/src/main/java/ppalatjyo/server/quiz/domain/Question.java
+++ b/server/src/main/java/ppalatjyo/server/quiz/domain/Question.java
@@ -23,15 +23,14 @@ public class Question {
     @OneToMany(mappedBy = "question", cascade = CascadeType.ALL, orphanRemoval = true)
     Set<Answer> answers = new HashSet<>();
 
-    public void setQuiz(Quiz quiz) {
-        this.quiz = quiz;
-    }
-
-    public static Question createQuestion(String content, Answer... answers) {
+    public static Question create(Quiz quiz, String content, Answer... answers) {
         Question question = Question.builder()
+                .quiz(quiz)
                 .content(content)
                 .answers(new HashSet<>())
                 .build();
+
+        quiz.addQuestion(question);
 
         for (Answer answer : answers) {
             question.addAnswer(answer);

--- a/server/src/main/java/ppalatjyo/server/quiz/domain/Question.java
+++ b/server/src/main/java/ppalatjyo/server/quiz/domain/Question.java
@@ -13,6 +13,7 @@ import java.util.Set;
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class Question {
     @Id @GeneratedValue
+    @Column(name = "question_id")
     private Long id;
     private String content;
 

--- a/server/src/main/java/ppalatjyo/server/quiz/domain/Quiz.java
+++ b/server/src/main/java/ppalatjyo/server/quiz/domain/Quiz.java
@@ -20,7 +20,7 @@ public class Quiz extends BaseEntity {
     @Id @GeneratedValue
     @Column(name = "quiz_id")
     private Long id;
-    private String name;
+    private String title;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
@@ -29,20 +29,20 @@ public class Quiz extends BaseEntity {
     @OneToMany(mappedBy = "quiz", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Question> questions = new ArrayList<>();
 
-    public static Quiz createQuiz(String name, User user) {
+    public static Quiz createQuiz(String title, User user) {
         if (user.getRole() == UserRole.GUEST) {
             throw new GuestCannotCreateQuizException();
         }
 
         return Quiz.builder()
-                .name(name)
+                .title(title)
                 .user(user)
                 .questions(new ArrayList<>())
                 .build();
     }
 
-    public void changeName(String name) {
-        this.name = name;
+    public void changeTitle(String title) {
+        this.title = title;
     }
 
     public void addQuestion(Question question) {

--- a/server/src/main/java/ppalatjyo/server/quiz/domain/Quiz.java
+++ b/server/src/main/java/ppalatjyo/server/quiz/domain/Quiz.java
@@ -34,7 +34,9 @@ public class Quiz extends BaseEntity {
     }
 
     public void addQuestion(Question question) {
-        question.setQuiz(this);
+        if (questions.contains(question)) {
+            return;
+        }
         questions.add(question);
     }
 }

--- a/server/src/main/java/ppalatjyo/server/quiz/domain/Quiz.java
+++ b/server/src/main/java/ppalatjyo/server/quiz/domain/Quiz.java
@@ -15,6 +15,7 @@ import java.util.List;
 public class Quiz extends BaseEntity {
 
     @Id @GeneratedValue
+    @Column(name = "quiz_id")
     private Long id;
     private String name;
 

--- a/server/src/main/java/ppalatjyo/server/quiz/domain/Quiz.java
+++ b/server/src/main/java/ppalatjyo/server/quiz/domain/Quiz.java
@@ -3,6 +3,9 @@ package ppalatjyo.server.quiz.domain;
 import jakarta.persistence.*;
 import lombok.*;
 import ppalatjyo.server.global.audit.BaseEntity;
+import ppalatjyo.server.quiz.GuestCannotCreateQuizException;
+import ppalatjyo.server.user.domain.User;
+import ppalatjyo.server.user.domain.UserRole;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -19,12 +22,21 @@ public class Quiz extends BaseEntity {
     private Long id;
     private String name;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
     @OneToMany(mappedBy = "quiz", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Question> questions = new ArrayList<>();
 
-    public static Quiz createQuiz(String name) {
+    public static Quiz createQuiz(String name, User user) {
+        if (user.getRole() == UserRole.GUEST) {
+            throw new GuestCannotCreateQuizException();
+        }
+
         return Quiz.builder()
                 .name(name)
+                .user(user)
                 .questions(new ArrayList<>())
                 .build();
     }

--- a/server/src/main/java/ppalatjyo/server/user/domain/User.java
+++ b/server/src/main/java/ppalatjyo/server/user/domain/User.java
@@ -16,6 +16,7 @@ public class User extends BaseEntity {
 
     @Id
     @GeneratedValue
+    @Column(name = "user_id")
     private Long id;
     private String nickname;
     private String oAuthEmail;

--- a/server/src/main/java/ppalatjyo/server/usergame/UserGame.java
+++ b/server/src/main/java/ppalatjyo/server/usergame/UserGame.java
@@ -1,0 +1,41 @@
+package ppalatjyo.server.usergame;
+
+import jakarta.persistence.*;
+import lombok.*;
+import ppalatjyo.server.game.Game;
+import ppalatjyo.server.global.audit.BaseEntity;
+import ppalatjyo.server.user.domain.User;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+public class UserGame extends BaseEntity {
+    @Id
+    @GeneratedValue
+    @Column(name = "user_game_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "game_id")
+    private Game game;
+
+    private int score;
+
+    public static UserGame join(User user, Game game) {
+        return UserGame.builder()
+                .user(user)
+                .game(game)
+                .score(0)
+                .build();
+    }
+
+    public void score() {
+        this.score++;
+    }
+}

--- a/server/src/main/java/ppalatjyo/server/userlobby/UserLobby.java
+++ b/server/src/main/java/ppalatjyo/server/userlobby/UserLobby.java
@@ -1,4 +1,19 @@
 package ppalatjyo.server.userlobby;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
 public class UserLobby {
+    @Id
+    @GeneratedValue
+    @Column(name = "user_lobby_id")
+    private Long id;
 }

--- a/server/src/main/java/ppalatjyo/server/userlobby/UserLobby.java
+++ b/server/src/main/java/ppalatjyo/server/userlobby/UserLobby.java
@@ -1,0 +1,4 @@
+package ppalatjyo.server.userlobby;
+
+public class UserLobby {
+}

--- a/server/src/main/java/ppalatjyo/server/userlobby/UserLobby.java
+++ b/server/src/main/java/ppalatjyo/server/userlobby/UserLobby.java
@@ -2,6 +2,7 @@ package ppalatjyo.server.userlobby;
 
 import jakarta.persistence.*;
 import lombok.*;
+import ppalatjyo.server.global.audit.BaseEntity;
 import ppalatjyo.server.lobby.domain.Lobby;
 import ppalatjyo.server.user.domain.User;
 
@@ -12,7 +13,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder(access = AccessLevel.PRIVATE)
-public class UserLobby {
+public class UserLobby extends BaseEntity {
     @Id
     @GeneratedValue
     @Column(name = "user_lobby_id")
@@ -39,5 +40,9 @@ public class UserLobby {
 
     public void leave() {
         this.leftAt = LocalDateTime.now();
+    }
+
+    public boolean isLeft() {
+        return this.leftAt != null;
     }
 }

--- a/server/src/main/java/ppalatjyo/server/userlobby/UserLobby.java
+++ b/server/src/main/java/ppalatjyo/server/userlobby/UserLobby.java
@@ -1,10 +1,11 @@
 package ppalatjyo.server.userlobby;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.*;
+import ppalatjyo.server.lobby.domain.Lobby;
+import ppalatjyo.server.user.domain.User;
+
+import java.time.LocalDateTime;
 
 @Entity
 @Getter
@@ -16,4 +17,27 @@ public class UserLobby {
     @GeneratedValue
     @Column(name = "user_lobby_id")
     private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "lobby_id")
+    private Lobby lobby;
+
+    private LocalDateTime joinedAt;
+    private LocalDateTime leftAt;
+
+    public static UserLobby join(User user, Lobby lobby) {
+        return UserLobby.builder()
+                .user(user)
+                .lobby(lobby)
+                .joinedAt(LocalDateTime.now())
+                .build();
+    }
+
+    public void leave() {
+        this.leftAt = LocalDateTime.now();
+    }
 }

--- a/server/src/test/java/ppalatjyo/server/game/GameTest.java
+++ b/server/src/test/java/ppalatjyo/server/game/GameTest.java
@@ -24,7 +24,7 @@ class GameTest {
         Quiz quiz = Quiz.createQuiz("quiz", User.createMember("n", "e", "p"));
         Question.create(quiz,"question1", Answer.createAnswer("answer1"));
 
-        Lobby lobby = Lobby.createLobby("lobby", user, quiz, LobbyOptions.createDefaultOptions());
+        Lobby lobby = Lobby.createLobby("lobby", user, quiz, LobbyOptions.defaultOptions());
 
         // when
         Game game = Game.start(lobby);
@@ -48,7 +48,7 @@ class GameTest {
         Quiz quiz = Quiz.createQuiz("quiz", User.createMember("n", "e", "p"));
         Question.create(quiz,"question1", Answer.createAnswer("answer1"));
 
-        Lobby lobby = Lobby.createLobby("lobby", user, quiz, LobbyOptions.createDefaultOptions());
+        Lobby lobby = Lobby.createLobby("lobby", user, quiz, LobbyOptions.defaultOptions());
         Game game = Game.start(lobby);
 
         // when
@@ -68,7 +68,7 @@ class GameTest {
         Quiz quiz = Quiz.createQuiz("quiz", User.createMember("n", "e", "p"));
         Question.create(quiz,"question1", Answer.createAnswer("answer1"));
 
-        Lobby lobby = Lobby.createLobby("lobby", user, quiz, LobbyOptions.createDefaultOptions());
+        Lobby lobby = Lobby.createLobby("lobby", user, quiz, LobbyOptions.defaultOptions());
         Game game = Game.start(lobby);
         game.end();
 
@@ -85,7 +85,7 @@ class GameTest {
         Quiz quiz = Quiz.createQuiz("quiz", User.createMember("n", "e", "p"));
         Question.create(quiz, "question1", Answer.createAnswer("answer1"));
         Question.create(quiz, "question2", Answer.createAnswer("answer2"));
-        Lobby lobby = Lobby.createLobby("lobby", user, quiz, LobbyOptions.createDefaultOptions());
+        Lobby lobby = Lobby.createLobby("lobby", user, quiz, LobbyOptions.defaultOptions());
 
         // when
         Game game = Game.start(lobby);
@@ -101,7 +101,7 @@ class GameTest {
         User user = User.createGuest("user");
         Quiz quiz = Quiz.createQuiz("quiz", User.createMember("n", "e", "p"));
         Question.create(quiz, "question1", Answer.createAnswer("answer1"));
-        Lobby lobby = Lobby.createLobby("lobby", user, quiz, LobbyOptions.createDefaultOptions());
+        Lobby lobby = Lobby.createLobby("lobby", user, quiz, LobbyOptions.defaultOptions());
 
         // when
         Game game = Game.start(lobby);
@@ -120,7 +120,7 @@ class GameTest {
         Question.create(quiz,"question1", Answer.createAnswer("answer1"));
         Question.create(quiz, "question2", Answer.createAnswer("answer2"));
 
-        Lobby lobby = Lobby.createLobby("lobby", user, quiz, LobbyOptions.createDefaultOptions());
+        Lobby lobby = Lobby.createLobby("lobby", user, quiz, LobbyOptions.defaultOptions());
         Game game = Game.start(lobby);
 
         // when
@@ -139,7 +139,7 @@ class GameTest {
         Quiz quiz = Quiz.createQuiz("quiz", User.createMember("n", "e", "p"));
         Question.create(quiz,"question1", Answer.createAnswer("answer1"));
 
-        Lobby lobby = Lobby.createLobby("lobby", user, quiz, LobbyOptions.createDefaultOptions());
+        Lobby lobby = Lobby.createLobby("lobby", user, quiz, LobbyOptions.defaultOptions());
         Game game = Game.start(lobby);
 
         // when

--- a/server/src/test/java/ppalatjyo/server/game/GameTest.java
+++ b/server/src/test/java/ppalatjyo/server/game/GameTest.java
@@ -1,0 +1,129 @@
+package ppalatjyo.server.game;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import ppalatjyo.server.lobby.domain.Lobby;
+import ppalatjyo.server.lobby.domain.LobbyOptions;
+import ppalatjyo.server.quiz.domain.Answer;
+import ppalatjyo.server.quiz.domain.Question;
+import ppalatjyo.server.quiz.domain.Quiz;
+import ppalatjyo.server.user.domain.User;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GameTest {
+
+    @Test
+    @DisplayName("Game 생성")
+    void start() {
+        // given
+        User user = User.createGuest("user");
+
+        Quiz quiz = Quiz.createQuiz("quiz");
+        Question.create(quiz,"question1", Answer.createAnswer("answer1"));
+
+        Lobby lobby = Lobby.createLobby("lobby", user, quiz, LobbyOptions.createDefaultOptions());
+
+        // when
+        Game game = Game.start(lobby);
+
+        // then
+        assertThat(game.getLobby()).isEqualTo(lobby);
+        assertThat(game.getQuiz()).isEqualTo(quiz);
+        assertThat(game.getCurrentQuestion()).isEqualTo(quiz.getQuestions().getFirst());
+        assertThat(game.getStartedAt()).isNotNull();
+        assertThat(game.getEndedAt()).isNull();
+    }
+
+    @Test
+    @DisplayName("Game 끝")
+    void end() {
+        // given
+        User user = User.createGuest("user");
+
+        Quiz quiz = Quiz.createQuiz("quiz");
+        Question.create(quiz,"question1", Answer.createAnswer("answer1"));
+
+        Lobby lobby = Lobby.createLobby("lobby", user, quiz, LobbyOptions.createDefaultOptions());
+        Game game = Game.start(lobby);
+
+        // when
+        game.end();
+
+        // then
+        assertThat(game.isEnded()).isTrue();
+        assertThat(game.getEndedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("다음 문제 확인 - 다음 문제가 있을 때 True 반환")
+    void hasNextQuestionTrue() {
+        // given
+        User user = User.createGuest("user");
+        Quiz quiz = Quiz.createQuiz("quiz");
+        Question.create(quiz, "question1", Answer.createAnswer("answer1"));
+        Question.create(quiz, "question2", Answer.createAnswer("answer2"));
+        Lobby lobby = Lobby.createLobby("lobby", user, quiz, LobbyOptions.createDefaultOptions());
+
+        // when
+        Game game = Game.start(lobby);
+
+        // then
+        assertThat(game.hasNextQuestion()).isTrue();
+    }
+
+    @Test
+    @DisplayName("다음 문제 확인 - 다음 문제가 없을 때 False 반환")
+    void hasNextQuestionFalse() {
+        // given
+        User user = User.createGuest("user");
+        Quiz quiz = Quiz.createQuiz("quiz");
+        Question.create(quiz, "question1", Answer.createAnswer("answer1"));
+        Lobby lobby = Lobby.createLobby("lobby", user, quiz, LobbyOptions.createDefaultOptions());
+
+        // when
+        Game game = Game.start(lobby);
+
+        // then
+        assertThat(game.hasNextQuestion()).isFalse();
+    }
+
+    @Test
+    @DisplayName("다음 문제 - 다음 문제가 있으면 넘어감")
+    void nextQuestion() {
+        // given
+        User user = User.createGuest("user");
+
+        Quiz quiz = Quiz.createQuiz("quiz");
+        Question.create(quiz,"question1", Answer.createAnswer("answer1"));
+        Question.create(quiz, "question2", Answer.createAnswer("answer2"));
+
+        Lobby lobby = Lobby.createLobby("lobby", user, quiz, LobbyOptions.createDefaultOptions());
+        Game game = Game.start(lobby);
+
+        // when
+        game.nextQuestion();
+
+        // then
+        assertThat(game.getCurrentQuestion()).isEqualTo(quiz.getQuestions().get(1));
+    }
+
+    @Test
+    @DisplayName("다음 문제 - 다음 문제가 없으면 게임 종료")
+    void endGameWhenNextQuestionNotExists() {
+        // given
+        User user = User.createGuest("user");
+
+        Quiz quiz = Quiz.createQuiz("quiz");
+        Question.create(quiz,"question1", Answer.createAnswer("answer1"));
+
+        Lobby lobby = Lobby.createLobby("lobby", user, quiz, LobbyOptions.createDefaultOptions());
+        Game game = Game.start(lobby);
+
+        // when
+        game.nextQuestion();
+
+        // then
+        assertThat(game.isEnded()).isTrue();
+    }
+}

--- a/server/src/test/java/ppalatjyo/server/game/GameTest.java
+++ b/server/src/test/java/ppalatjyo/server/game/GameTest.java
@@ -21,7 +21,7 @@ class GameTest {
         // given
         User user = User.createGuest("user");
 
-        Quiz quiz = Quiz.createQuiz("quiz");
+        Quiz quiz = Quiz.createQuiz("quiz", User.createMember("n", "e", "p"));
         Question.create(quiz,"question1", Answer.createAnswer("answer1"));
 
         Lobby lobby = Lobby.createLobby("lobby", user, quiz, LobbyOptions.createDefaultOptions());
@@ -45,7 +45,7 @@ class GameTest {
         // given
         User user = User.createGuest("user");
 
-        Quiz quiz = Quiz.createQuiz("quiz");
+        Quiz quiz = Quiz.createQuiz("quiz", User.createMember("n", "e", "p"));
         Question.create(quiz,"question1", Answer.createAnswer("answer1"));
 
         Lobby lobby = Lobby.createLobby("lobby", user, quiz, LobbyOptions.createDefaultOptions());
@@ -65,7 +65,7 @@ class GameTest {
         // given
         User user = User.createGuest("user");
 
-        Quiz quiz = Quiz.createQuiz("quiz");
+        Quiz quiz = Quiz.createQuiz("quiz", User.createMember("n", "e", "p"));
         Question.create(quiz,"question1", Answer.createAnswer("answer1"));
 
         Lobby lobby = Lobby.createLobby("lobby", user, quiz, LobbyOptions.createDefaultOptions());
@@ -82,7 +82,7 @@ class GameTest {
     void hasNextQuestionTrue() {
         // given
         User user = User.createGuest("user");
-        Quiz quiz = Quiz.createQuiz("quiz");
+        Quiz quiz = Quiz.createQuiz("quiz", User.createMember("n", "e", "p"));
         Question.create(quiz, "question1", Answer.createAnswer("answer1"));
         Question.create(quiz, "question2", Answer.createAnswer("answer2"));
         Lobby lobby = Lobby.createLobby("lobby", user, quiz, LobbyOptions.createDefaultOptions());
@@ -99,7 +99,7 @@ class GameTest {
     void hasNextQuestionFalse() {
         // given
         User user = User.createGuest("user");
-        Quiz quiz = Quiz.createQuiz("quiz");
+        Quiz quiz = Quiz.createQuiz("quiz", User.createMember("n", "e", "p"));
         Question.create(quiz, "question1", Answer.createAnswer("answer1"));
         Lobby lobby = Lobby.createLobby("lobby", user, quiz, LobbyOptions.createDefaultOptions());
 
@@ -116,7 +116,7 @@ class GameTest {
         // given
         User user = User.createGuest("user");
 
-        Quiz quiz = Quiz.createQuiz("quiz");
+        Quiz quiz = Quiz.createQuiz("quiz", User.createMember("n", "e", "p"));
         Question.create(quiz,"question1", Answer.createAnswer("answer1"));
         Question.create(quiz, "question2", Answer.createAnswer("answer2"));
 
@@ -136,7 +136,7 @@ class GameTest {
         // given
         User user = User.createGuest("user");
 
-        Quiz quiz = Quiz.createQuiz("quiz");
+        Quiz quiz = Quiz.createQuiz("quiz", User.createMember("n", "e", "p"));
         Question.create(quiz,"question1", Answer.createAnswer("answer1"));
 
         Lobby lobby = Lobby.createLobby("lobby", user, quiz, LobbyOptions.createDefaultOptions());

--- a/server/src/test/java/ppalatjyo/server/gameevent/GameEventTest.java
+++ b/server/src/test/java/ppalatjyo/server/gameevent/GameEventTest.java
@@ -1,0 +1,117 @@
+package ppalatjyo.server.gameevent;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import ppalatjyo.server.game.Game;
+import ppalatjyo.server.lobby.domain.Lobby;
+import ppalatjyo.server.lobby.domain.LobbyOptions;
+import ppalatjyo.server.message.Message;
+import ppalatjyo.server.quiz.domain.Answer;
+import ppalatjyo.server.quiz.domain.Question;
+import ppalatjyo.server.quiz.domain.Quiz;
+import ppalatjyo.server.user.domain.User;
+import ppalatjyo.server.usergame.UserGame;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GameEventTest {
+
+    @Test
+    @DisplayName("게임 시작됨")
+    void gameStartedEvent () {
+        // given
+        User user = User.createGuest("guest");
+        Lobby lobby = Lobby.createLobby("lobby", user, getQuiz(), LobbyOptions.defaultOptions());
+        Game game = Game.start(lobby);
+        UserGame userGame = UserGame.join(user, game);
+
+        // when
+        GameEvent gameEvent = GameEvent.started(game, userGame);
+
+        // then
+        assertThat(gameEvent.getGame()).isEqualTo(game);
+        assertThat(gameEvent.getUserGame()).isEqualTo(userGame);
+        assertThat(gameEvent.getType()).isEqualTo(GameEventType.GAME_STARTED);
+    }
+
+    @Test
+    @DisplayName("게임 종료됨")
+    void gameEndedEvent () {
+        // given
+        User user = User.createGuest("guest");
+        Lobby lobby = Lobby.createLobby("lobby", user, getQuiz(), LobbyOptions.defaultOptions());
+        Game game = Game.start(lobby);
+
+        // when
+        GameEvent gameEvent = GameEvent.ended(game);
+
+        // then
+        assertThat(gameEvent.getGame()).isEqualTo(game);
+        assertThat(gameEvent.getType()).isEqualTo(GameEventType.GAME_ENDED);
+    }
+
+    @Test
+    @DisplayName("오답")
+    void wrongAnswer() {
+        // given
+        String wrongAnswer = "Wrong Answer";
+        User user = User.createGuest("guest");
+        Lobby lobby = Lobby.createLobby("lobby", user, getQuiz(), LobbyOptions.defaultOptions());
+        Game game = Game.start(lobby);
+        UserGame userGame = UserGame.join(user, game);
+        Message message = Message.create(wrongAnswer, user, lobby, game);
+
+        // when
+        GameEvent gameEvent = GameEvent.wrongAnswer(game, userGame, message);
+
+        // then
+        assertThat(gameEvent.getType()).isEqualTo(GameEventType.WRONG_ANSWER);
+        assertThat(gameEvent.getGame()).isEqualTo(game);
+        assertThat(gameEvent.getUserGame()).isEqualTo(userGame);
+        assertThat(gameEvent.getMessage()).isEqualTo(message);
+    }
+
+    @Test
+    @DisplayName("정답")
+    void rightAnswer() {
+        // given
+        String rightAnswer = "Right Answer";
+        User user = User.createGuest("guest");
+        Lobby lobby = Lobby.createLobby("lobby", user, getQuiz(), LobbyOptions.defaultOptions());
+        Game game = Game.start(lobby);
+        UserGame userGame = UserGame.join(user, game);
+        Message message = Message.create(rightAnswer, user, lobby, game);
+
+        // when
+        GameEvent gameEvent = GameEvent.rightAnswer(game, userGame, message);
+
+        // then
+        assertThat(gameEvent.getType()).isEqualTo(GameEventType.RIGHT_ANSWER);
+        assertThat(gameEvent.getGame()).isEqualTo(game);
+        assertThat(gameEvent.getUserGame()).isEqualTo(userGame);
+        assertThat(gameEvent.getMessage()).isEqualTo(message);
+    }
+
+    @Test
+    @DisplayName("시간 초과")
+    void timeOut() {
+        // given
+        User user = User.createGuest("guest");
+        Lobby lobby = Lobby.createLobby("lobby", user, getQuiz(), LobbyOptions.defaultOptions());
+        Game game = Game.start(lobby);
+
+        // when
+        GameEvent gameEvent = GameEvent.timeOut(game);
+
+        // then
+        assertThat(gameEvent.getType()).isEqualTo(GameEventType.TIME_OUT);
+        assertThat(gameEvent.getGame()).isEqualTo(game);
+    }
+
+    private Quiz getQuiz() {
+        Quiz quiz = Quiz.createQuiz("quiz", User.createMember("n", "e", "p"));
+        Question.create(quiz,"question1", Answer.createAnswer("answer1"));
+        Question.create(quiz, "question2", Answer.createAnswer("answer2"));
+        return quiz;
+    }
+}

--- a/server/src/test/java/ppalatjyo/server/lobby/LobbyServiceTest.java
+++ b/server/src/test/java/ppalatjyo/server/lobby/LobbyServiceTest.java
@@ -38,6 +38,7 @@ class LobbyServiceTest {
     @DisplayName("Lobby 생성")
     void createLobby() {
         // given
+        String name = "lobby";
         User host = User.createGuest("host");
         Quiz quiz = Quiz.createQuiz("quiz");
         long hostId = 1L;
@@ -52,13 +53,14 @@ class LobbyServiceTest {
         LobbyOptions options = LobbyOptions.createOptions(maxUsers, minPerGame, secPerQuestion);
 
         // when
-        lobbyService.createLobby(hostId, quizId, options);
+        lobbyService.createLobby(name, hostId, quizId, options);
 
         // then
         ArgumentCaptor<Lobby> captor = ArgumentCaptor.forClass(Lobby.class);
         verify(lobbyRepository, times(1)).save(captor.capture());
 
         Lobby createdLobby = captor.getValue();
+        assertThat(createdLobby.getName()).isEqualTo(name);
         assertThat(createdLobby.getHost()).isEqualTo(host);
         assertThat(createdLobby.getQuiz()).isEqualTo(quiz);
         assertThat(createdLobby.getOptions().getMaxUsers()).isEqualTo(maxUsers);
@@ -68,10 +70,11 @@ class LobbyServiceTest {
     @DisplayName("Lobby 옵션 변경")
     void changeOptions() throws InterruptedException {
         // given
+        String name = "lobby";
         User host = User.createGuest("host");
         Quiz quiz = Quiz.createQuiz("quiz");
         LobbyOptions options = LobbyOptions.createOptions(10, 10, 10);
-        Lobby lobby = Lobby.createLobby(host, quiz, options);
+        Lobby lobby = Lobby.createLobby(name, host, quiz, options);
 
         long lobbyId = 1L;
         when(lobbyRepository.findById(lobbyId)).thenReturn(Optional.of(lobby));
@@ -91,10 +94,11 @@ class LobbyServiceTest {
     @DisplayName("Lobby 삭제")
     void deleteLobby() {
         // given
+        String name = "lobby";
         User host = User.createGuest("host");
         Quiz quiz = Quiz.createQuiz("quiz");
         LobbyOptions options = LobbyOptions.createOptions(10, 10, 10);
-        Lobby lobby = Lobby.createLobby(host, quiz, options);
+        Lobby lobby = Lobby.createLobby(name, host, quiz, options);
 
         long lobbyId = 1L;
         when(lobbyRepository.findById(lobbyId)).thenReturn(Optional.of(lobby));
@@ -110,11 +114,12 @@ class LobbyServiceTest {
     @DisplayName("Host 변경")
     void changeHost() {
         // given
+        String name = "lobby";
         User oldHost = User.createGuest("oldHost");
         User newHost = User.createGuest("newHost");
         Quiz quiz = Quiz.createQuiz("quiz");
         LobbyOptions options = LobbyOptions.createOptions(10, 10, 10);
-        Lobby lobby = Lobby.createLobby(oldHost, quiz, options);
+        Lobby lobby = Lobby.createLobby(name, oldHost, quiz, options);
 
         long lobbyId = 1L;
         long newHostId = 1L;
@@ -134,7 +139,7 @@ class LobbyServiceTest {
         // given
         Quiz oldQuiz = Quiz.createQuiz("oldQuiz");
         Quiz newQuiz = Quiz.createQuiz("newQuiz");
-        Lobby lobby = Lobby.createLobby(User.createGuest("host"), oldQuiz, LobbyOptions.createOptions(1, 1, 1));
+        Lobby lobby = Lobby.createLobby("lobby", User.createGuest("host"), oldQuiz, LobbyOptions.createOptions(1, 1, 1));
 
         long newQuizId = 1L;
         long lobbyId = 1L;

--- a/server/src/test/java/ppalatjyo/server/lobby/LobbyServiceTest.java
+++ b/server/src/test/java/ppalatjyo/server/lobby/LobbyServiceTest.java
@@ -40,7 +40,7 @@ class LobbyServiceTest {
         // given
         String name = "lobby";
         User host = User.createGuest("host");
-        Quiz quiz = Quiz.createQuiz("quiz");
+        Quiz quiz = Quiz.createQuiz("quiz", User.createMember("n", "e", "p"));
         long hostId = 1L;
         long quizId = 1L;
         int maxUsers = 10;
@@ -72,7 +72,7 @@ class LobbyServiceTest {
         // given
         String name = "lobby";
         User host = User.createGuest("host");
-        Quiz quiz = Quiz.createQuiz("quiz");
+        Quiz quiz = Quiz.createQuiz("quiz", User.createMember("n", "e", "p"));
         LobbyOptions options = LobbyOptions.createOptions(10, 10, 10);
         Lobby lobby = Lobby.createLobby(name, host, quiz, options);
 
@@ -96,7 +96,7 @@ class LobbyServiceTest {
         // given
         String name = "lobby";
         User host = User.createGuest("host");
-        Quiz quiz = Quiz.createQuiz("quiz");
+        Quiz quiz = Quiz.createQuiz("quiz", User.createMember("n", "e", "p"));
         LobbyOptions options = LobbyOptions.createOptions(10, 10, 10);
         Lobby lobby = Lobby.createLobby(name, host, quiz, options);
 
@@ -117,7 +117,7 @@ class LobbyServiceTest {
         String name = "lobby";
         User oldHost = User.createGuest("oldHost");
         User newHost = User.createGuest("newHost");
-        Quiz quiz = Quiz.createQuiz("quiz");
+        Quiz quiz = Quiz.createQuiz("quiz", User.createMember("n", "e", "p"));
         LobbyOptions options = LobbyOptions.createOptions(10, 10, 10);
         Lobby lobby = Lobby.createLobby(name, oldHost, quiz, options);
 
@@ -137,8 +137,8 @@ class LobbyServiceTest {
     @DisplayName("Quiz 변경")
     void changeQuiz() {
         // given
-        Quiz oldQuiz = Quiz.createQuiz("oldQuiz");
-        Quiz newQuiz = Quiz.createQuiz("newQuiz");
+        Quiz oldQuiz = Quiz.createQuiz("oldQuiz", User.createMember("n", "e", "p"));
+        Quiz newQuiz = Quiz.createQuiz("newQuiz", User.createMember("n", "e", "p"));
         Lobby lobby = Lobby.createLobby("lobby", User.createGuest("host"), oldQuiz, LobbyOptions.createOptions(1, 1, 1));
 
         long newQuizId = 1L;

--- a/server/src/test/java/ppalatjyo/server/lobby/LobbyTest.java
+++ b/server/src/test/java/ppalatjyo/server/lobby/LobbyTest.java
@@ -43,7 +43,7 @@ class LobbyTest {
         // given
         String oldName = "oldName";
         String newName = "newName";
-        Lobby lobby = Lobby.createLobby(oldName, User.createGuest("host"), Quiz.createQuiz("quiz", User.createMember("n", "e", "p")), LobbyOptions.createDefaultOptions());
+        Lobby lobby = Lobby.createLobby(oldName, User.createGuest("host"), Quiz.createQuiz("quiz", User.createMember("n", "e", "p")), LobbyOptions.defaultOptions());
 
         // when
         lobby.changeName(newName);
@@ -56,7 +56,7 @@ class LobbyTest {
     @DisplayName("Lobby 삭제")
     void deleteLobby() {
         // given
-        Lobby lobby = Lobby.createLobby("lobby", User.createGuest("host"), Quiz.createQuiz("quiz", User.createMember("n", "e", "p")), LobbyOptions.createDefaultOptions());
+        Lobby lobby = Lobby.createLobby("lobby", User.createGuest("host"), Quiz.createQuiz("quiz", User.createMember("n", "e", "p")), LobbyOptions.defaultOptions());
 
         // when
         lobby.delete();
@@ -69,7 +69,7 @@ class LobbyTest {
     @DisplayName("삭제된 Lobby는 삭제할 수 없음")
     void lobbyAlreadyDeleted() {
         // given
-        Lobby lobby = Lobby.createLobby("lobby", User.createGuest("host"), Quiz.createQuiz("quiz", User.createMember("n", "e", "p")), LobbyOptions.createDefaultOptions());
+        Lobby lobby = Lobby.createLobby("lobby", User.createGuest("host"), Quiz.createQuiz("quiz", User.createMember("n", "e", "p")), LobbyOptions.defaultOptions());
         lobby.delete();
 
         // when
@@ -84,7 +84,7 @@ class LobbyTest {
         User oldHost = User.createGuest("oldHost");
         User newHost = User.createGuest("newHost");
 
-        Lobby lobby = Lobby.createLobby("lobby", oldHost, Quiz.createQuiz("quiz", User.createMember("n", "e", "p")), LobbyOptions.createDefaultOptions());
+        Lobby lobby = Lobby.createLobby("lobby", oldHost, Quiz.createQuiz("quiz", User.createMember("n", "e", "p")), LobbyOptions.defaultOptions());
 
         // when
         lobby.changeHost(newHost);
@@ -115,7 +115,7 @@ class LobbyTest {
     void changeQuiz() {
         // given
         Quiz oldQuiz = Quiz.createQuiz("oldQuiz", User.createMember("n", "e", "p"));
-        Lobby lobby = Lobby.createLobby("lobby", User.createGuest("host"), oldQuiz, LobbyOptions.createDefaultOptions());
+        Lobby lobby = Lobby.createLobby("lobby", User.createGuest("host"), oldQuiz, LobbyOptions.defaultOptions());
 
         Quiz newQuiz = Quiz.createQuiz("newQuiz", User.createMember("n", "e", "p"));
 

--- a/server/src/test/java/ppalatjyo/server/lobby/LobbyTest.java
+++ b/server/src/test/java/ppalatjyo/server/lobby/LobbyTest.java
@@ -38,6 +38,21 @@ class LobbyTest {
     }
 
     @Test
+    @DisplayName("Lobby 이름 변경")
+    void changeName() {
+        // given
+        String oldName = "oldName";
+        String newName = "newName";
+        Lobby lobby = Lobby.createLobby(oldName, User.createGuest("host"), Quiz.createQuiz("quiz"), LobbyOptions.createOptions(1, 1, 1));
+
+        // when
+        lobby.changeName(newName);
+
+        // then
+        assertThat(lobby.getName()).isEqualTo(newName);
+    }
+
+    @Test
     @DisplayName("Lobby 삭제")
     void deleteLobby() {
         // given

--- a/server/src/test/java/ppalatjyo/server/lobby/LobbyTest.java
+++ b/server/src/test/java/ppalatjyo/server/lobby/LobbyTest.java
@@ -43,7 +43,7 @@ class LobbyTest {
         // given
         String oldName = "oldName";
         String newName = "newName";
-        Lobby lobby = Lobby.createLobby(oldName, User.createGuest("host"), Quiz.createQuiz("quiz"), LobbyOptions.createOptions(1, 1, 1));
+        Lobby lobby = Lobby.createLobby(oldName, User.createGuest("host"), Quiz.createQuiz("quiz"), LobbyOptions.createDefaultOptions());
 
         // when
         lobby.changeName(newName);
@@ -56,7 +56,7 @@ class LobbyTest {
     @DisplayName("Lobby 삭제")
     void deleteLobby() {
         // given
-        Lobby lobby = Lobby.createLobby("lobby", User.createGuest("host"), Quiz.createQuiz("quiz"), LobbyOptions.createOptions(1, 1, 1));
+        Lobby lobby = Lobby.createLobby("lobby", User.createGuest("host"), Quiz.createQuiz("quiz"), LobbyOptions.createDefaultOptions());
 
         // when
         lobby.delete();
@@ -69,7 +69,7 @@ class LobbyTest {
     @DisplayName("삭제된 Lobby는 삭제할 수 없음")
     void lobbyAlreadyDeleted() {
         // given
-        Lobby lobby = Lobby.createLobby("lobby", User.createGuest("host"), Quiz.createQuiz("quiz"), LobbyOptions.createOptions(1, 1, 1));
+        Lobby lobby = Lobby.createLobby("lobby", User.createGuest("host"), Quiz.createQuiz("quiz"), LobbyOptions.createDefaultOptions());
         lobby.delete();
 
         // when
@@ -84,7 +84,7 @@ class LobbyTest {
         User oldHost = User.createGuest("oldHost");
         User newHost = User.createGuest("newHost");
 
-        Lobby lobby = Lobby.createLobby("lobby", oldHost, Quiz.createQuiz("quiz"), LobbyOptions.createOptions(1, 1, 1));
+        Lobby lobby = Lobby.createLobby("lobby", oldHost, Quiz.createQuiz("quiz"), LobbyOptions.createDefaultOptions());
 
         // when
         lobby.changeHost(newHost);
@@ -115,7 +115,7 @@ class LobbyTest {
     void changeQuiz() {
         // given
         Quiz oldQuiz = Quiz.createQuiz("oldQuiz");
-        Lobby lobby = Lobby.createLobby("lobby", User.createGuest("host"), oldQuiz, LobbyOptions.createOptions(1, 1, 1));
+        Lobby lobby = Lobby.createLobby("lobby", User.createGuest("host"), oldQuiz, LobbyOptions.createDefaultOptions());
 
         Quiz newQuiz = Quiz.createQuiz("newQuiz");
 

--- a/server/src/test/java/ppalatjyo/server/lobby/LobbyTest.java
+++ b/server/src/test/java/ppalatjyo/server/lobby/LobbyTest.java
@@ -18,7 +18,7 @@ class LobbyTest {
         // given
         String name = "name";
         User host = User.createGuest("user");
-        Quiz quiz = Quiz.createQuiz("quiz");
+        Quiz quiz = Quiz.createQuiz("quiz", User.createMember("n", "e", "p"));
         int maxUsers = 10;
         int minPerGame = 10;
         int secPerQuestion = 60;
@@ -43,7 +43,7 @@ class LobbyTest {
         // given
         String oldName = "oldName";
         String newName = "newName";
-        Lobby lobby = Lobby.createLobby(oldName, User.createGuest("host"), Quiz.createQuiz("quiz"), LobbyOptions.createDefaultOptions());
+        Lobby lobby = Lobby.createLobby(oldName, User.createGuest("host"), Quiz.createQuiz("quiz", User.createMember("n", "e", "p")), LobbyOptions.createDefaultOptions());
 
         // when
         lobby.changeName(newName);
@@ -56,7 +56,7 @@ class LobbyTest {
     @DisplayName("Lobby 삭제")
     void deleteLobby() {
         // given
-        Lobby lobby = Lobby.createLobby("lobby", User.createGuest("host"), Quiz.createQuiz("quiz"), LobbyOptions.createDefaultOptions());
+        Lobby lobby = Lobby.createLobby("lobby", User.createGuest("host"), Quiz.createQuiz("quiz", User.createMember("n", "e", "p")), LobbyOptions.createDefaultOptions());
 
         // when
         lobby.delete();
@@ -69,7 +69,7 @@ class LobbyTest {
     @DisplayName("삭제된 Lobby는 삭제할 수 없음")
     void lobbyAlreadyDeleted() {
         // given
-        Lobby lobby = Lobby.createLobby("lobby", User.createGuest("host"), Quiz.createQuiz("quiz"), LobbyOptions.createDefaultOptions());
+        Lobby lobby = Lobby.createLobby("lobby", User.createGuest("host"), Quiz.createQuiz("quiz", User.createMember("n", "e", "p")), LobbyOptions.createDefaultOptions());
         lobby.delete();
 
         // when
@@ -84,7 +84,7 @@ class LobbyTest {
         User oldHost = User.createGuest("oldHost");
         User newHost = User.createGuest("newHost");
 
-        Lobby lobby = Lobby.createLobby("lobby", oldHost, Quiz.createQuiz("quiz"), LobbyOptions.createDefaultOptions());
+        Lobby lobby = Lobby.createLobby("lobby", oldHost, Quiz.createQuiz("quiz", User.createMember("n", "e", "p")), LobbyOptions.createDefaultOptions());
 
         // when
         lobby.changeHost(newHost);
@@ -98,7 +98,7 @@ class LobbyTest {
     void changeOptions() {
         // given
         LobbyOptions options = LobbyOptions.createOptions(10, 10, 10);
-        Lobby lobby = Lobby.createLobby("lobby", User.createGuest("host"), Quiz.createQuiz("quiz"), options);
+        Lobby lobby = Lobby.createLobby("lobby", User.createGuest("host"), Quiz.createQuiz("quiz", User.createMember("n", "e", "p")), options);
         LobbyOptions newOptions = LobbyOptions.createOptions(20, 20, 20);
 
         // when
@@ -114,10 +114,10 @@ class LobbyTest {
     @DisplayName("Quiz 변경")
     void changeQuiz() {
         // given
-        Quiz oldQuiz = Quiz.createQuiz("oldQuiz");
+        Quiz oldQuiz = Quiz.createQuiz("oldQuiz", User.createMember("n", "e", "p"));
         Lobby lobby = Lobby.createLobby("lobby", User.createGuest("host"), oldQuiz, LobbyOptions.createDefaultOptions());
 
-        Quiz newQuiz = Quiz.createQuiz("newQuiz");
+        Quiz newQuiz = Quiz.createQuiz("newQuiz", User.createMember("n", "e", "p"));
 
         // when
         lobby.changeQuiz(newQuiz);

--- a/server/src/test/java/ppalatjyo/server/lobby/LobbyTest.java
+++ b/server/src/test/java/ppalatjyo/server/lobby/LobbyTest.java
@@ -16,6 +16,7 @@ class LobbyTest {
     @DisplayName("Lobby 생성")
     void createLobby() {
         // given
+        String name = "name";
         User host = User.createGuest("user");
         Quiz quiz = Quiz.createQuiz("quiz");
         int maxUsers = 10;
@@ -25,9 +26,10 @@ class LobbyTest {
         LobbyOptions options = LobbyOptions.createOptions(maxUsers, minPerGame, secPerQuestion);
 
         // when
-        Lobby lobby = Lobby.createLobby(host, quiz, options);
+        Lobby lobby = Lobby.createLobby(name, host, quiz, options);
 
         // then
+        assertThat(lobby.getName()).isEqualTo(name);
         assertThat(lobby.getHost()).isEqualTo(host);
         assertThat(lobby.getQuiz()).isEqualTo(quiz);
         assertThat(lobby.getOptions().getMaxUsers()).isEqualTo(maxUsers);
@@ -39,7 +41,7 @@ class LobbyTest {
     @DisplayName("Lobby 삭제")
     void deleteLobby() {
         // given
-        Lobby lobby = Lobby.createLobby(User.createGuest("host"), Quiz.createQuiz("quiz"), LobbyOptions.createOptions(1, 1, 1));
+        Lobby lobby = Lobby.createLobby("lobby", User.createGuest("host"), Quiz.createQuiz("quiz"), LobbyOptions.createOptions(1, 1, 1));
 
         // when
         lobby.delete();
@@ -52,7 +54,7 @@ class LobbyTest {
     @DisplayName("삭제된 Lobby는 삭제할 수 없음")
     void lobbyAlreadyDeleted() {
         // given
-        Lobby lobby = Lobby.createLobby(User.createGuest("host"), Quiz.createQuiz("quiz"), LobbyOptions.createOptions(1, 1, 1));
+        Lobby lobby = Lobby.createLobby("lobby", User.createGuest("host"), Quiz.createQuiz("quiz"), LobbyOptions.createOptions(1, 1, 1));
         lobby.delete();
 
         // when
@@ -67,7 +69,7 @@ class LobbyTest {
         User oldHost = User.createGuest("oldHost");
         User newHost = User.createGuest("newHost");
 
-        Lobby lobby = Lobby.createLobby(oldHost, Quiz.createQuiz("quiz"), LobbyOptions.createOptions(1, 1, 1));
+        Lobby lobby = Lobby.createLobby("lobby", oldHost, Quiz.createQuiz("quiz"), LobbyOptions.createOptions(1, 1, 1));
 
         // when
         lobby.changeHost(newHost);
@@ -81,7 +83,7 @@ class LobbyTest {
     void changeOptions() {
         // given
         LobbyOptions options = LobbyOptions.createOptions(10, 10, 10);
-        Lobby lobby = Lobby.createLobby(User.createGuest("host"), Quiz.createQuiz("quiz"), options);
+        Lobby lobby = Lobby.createLobby("lobby", User.createGuest("host"), Quiz.createQuiz("quiz"), options);
         LobbyOptions newOptions = LobbyOptions.createOptions(20, 20, 20);
 
         // when
@@ -98,7 +100,7 @@ class LobbyTest {
     void changeQuiz() {
         // given
         Quiz oldQuiz = Quiz.createQuiz("oldQuiz");
-        Lobby lobby = Lobby.createLobby(User.createGuest("host"), oldQuiz, LobbyOptions.createOptions(1, 1, 1));
+        Lobby lobby = Lobby.createLobby("lobby", User.createGuest("host"), oldQuiz, LobbyOptions.createOptions(1, 1, 1));
 
         Quiz newQuiz = Quiz.createQuiz("newQuiz");
 

--- a/server/src/test/java/ppalatjyo/server/message/MessageTest.java
+++ b/server/src/test/java/ppalatjyo/server/message/MessageTest.java
@@ -1,0 +1,59 @@
+package ppalatjyo.server.message;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import ppalatjyo.server.game.Game;
+import ppalatjyo.server.lobby.domain.Lobby;
+import ppalatjyo.server.lobby.domain.LobbyOptions;
+import ppalatjyo.server.quiz.domain.Answer;
+import ppalatjyo.server.quiz.domain.Question;
+import ppalatjyo.server.quiz.domain.Quiz;
+import ppalatjyo.server.user.domain.User;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MessageTest {
+
+    @Test
+    @DisplayName("메시지 생성: 유저 -> 로비")
+    void create() {
+        // given
+        String content = "content";
+        User user = User.createGuest("user");
+        Lobby lobby = Lobby.createLobby("lobby", user, null, LobbyOptions.defaultOptions());
+
+        // when
+        Message message = Message.create(content, user, lobby);
+
+        // then
+        assertThat(message.getContent()).isEqualTo(content);
+        assertThat(message.getUser()).isEqualTo(user);
+        assertThat(message.getLobby()).isEqualTo(lobby);
+    }
+
+    @Test
+    @DisplayName("메시지 생성: 유저 -> 게임")
+    void createToGame() {
+        // given
+        String content = "content";
+        User user = User.createGuest("user");
+        Lobby lobby = Lobby.createLobby("lobby", user, getQuiz(), LobbyOptions.defaultOptions());
+        Game game = Game.start(lobby);
+
+        // when
+        Message message = Message.create(content, user, lobby, game);
+
+        // then
+        assertThat(message.getContent()).isEqualTo(content);
+        assertThat(message.getUser()).isEqualTo(user);
+        assertThat(message.getLobby()).isEqualTo(lobby);
+        assertThat(message.getGame()).isEqualTo(game);
+    }
+
+    private Quiz getQuiz() {
+        Quiz quiz = Quiz.createQuiz("quiz", User.createMember("n", "e", "p"));
+        Question.create(quiz,"question1", Answer.createAnswer("answer1"));
+        Question.create(quiz, "question2", Answer.createAnswer("answer2"));
+        return quiz;
+    }
+}

--- a/server/src/test/java/ppalatjyo/server/quiz/QuizTest.java
+++ b/server/src/test/java/ppalatjyo/server/quiz/QuizTest.java
@@ -1,10 +1,12 @@
 package ppalatjyo.server.quiz;
 
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import ppalatjyo.server.quiz.domain.Answer;
 import ppalatjyo.server.quiz.domain.Question;
 import ppalatjyo.server.quiz.domain.Quiz;
+import ppalatjyo.server.user.domain.User;
 
 import java.util.List;
 
@@ -17,19 +19,34 @@ class QuizTest {
     void createQuiz() {
         // given
         String name = "quiz";
+        User member = User.createMember("author", "test@email.com", "google");
 
         // when
-        Quiz quiz = Quiz.createQuiz(name);
+        Quiz quiz = Quiz.createQuiz(name, member);
 
         // then
         assertThat(quiz.getName()).isEqualTo(name);
+        assertThat(quiz.getUser()).isEqualTo(member);
+    }
+
+    @Test
+    @DisplayName("Quiz 생성 - Guest가 생성 시도 시 예외 발생")
+    void createQuizExceptionWhenGuest() {
+        // given
+        String name = "quiz";
+        User user = User.createGuest("guest");
+
+        // when
+        // then
+        Assertions.assertThatThrownBy(() -> Quiz.createQuiz(name, user))
+                .isInstanceOf(GuestCannotCreateQuizException.class);
     }
 
     @Test
     @DisplayName("Quiz 이름 수정")
     void changeName() {
         // given
-        Quiz quiz = Quiz.createQuiz("oldName");
+        Quiz quiz = Quiz.createQuiz("oldName", User.createMember("n", "e", "p"));
         String name = "newName";
 
         // when
@@ -43,7 +60,7 @@ class QuizTest {
     @DisplayName("문제 추가")
     void addQuestion() {
         // given
-        Quiz quiz = Quiz.createQuiz("quiz");
+        Quiz quiz = Quiz.createQuiz("quiz", User.createMember("n", "e", "p"));
 
         Answer answer1 = Answer.createAnswer("answer1");
         Answer answer2 = Answer.createAnswer("answer2");
@@ -55,7 +72,7 @@ class QuizTest {
         // then
         List<Question> questions = quiz.getQuestions();
         assertThat(questions.size()).isEqualTo(1);
-        assertThat(questions.get(0)).isEqualTo(question);
-        assertThat(questions.get(0).getAnswers().size()).isEqualTo(2);
+        assertThat(questions.getFirst()).isEqualTo(question);
+        assertThat(questions.getFirst().getAnswers().size()).isEqualTo(2);
     }
 }

--- a/server/src/test/java/ppalatjyo/server/quiz/QuizTest.java
+++ b/server/src/test/java/ppalatjyo/server/quiz/QuizTest.java
@@ -25,7 +25,7 @@ class QuizTest {
         Quiz quiz = Quiz.createQuiz(name, member);
 
         // then
-        assertThat(quiz.getName()).isEqualTo(name);
+        assertThat(quiz.getTitle()).isEqualTo(name);
         assertThat(quiz.getUser()).isEqualTo(member);
     }
 
@@ -44,16 +44,16 @@ class QuizTest {
 
     @Test
     @DisplayName("Quiz 이름 수정")
-    void changeName() {
+    void changeTitle() {
         // given
         Quiz quiz = Quiz.createQuiz("oldName", User.createMember("n", "e", "p"));
         String name = "newName";
 
         // when
-        quiz.changeName(name);
+        quiz.changeTitle(name);
 
         // then
-        assertThat(quiz.getName()).isEqualTo(name);
+        assertThat(quiz.getTitle()).isEqualTo(name);
     }
 
     @Test

--- a/server/src/test/java/ppalatjyo/server/quiz/QuizTest.java
+++ b/server/src/test/java/ppalatjyo/server/quiz/QuizTest.java
@@ -47,7 +47,7 @@ class QuizTest {
 
         Answer answer1 = Answer.createAnswer("answer1");
         Answer answer2 = Answer.createAnswer("answer2");
-        Question question = Question.createQuestion("content", answer1, answer2);
+        Question question = Question.create(quiz, "content", answer1, answer2);
 
         // when
         quiz.addQuestion(question);

--- a/server/src/test/java/ppalatjyo/server/quiz/domain/QuestionTest.java
+++ b/server/src/test/java/ppalatjyo/server/quiz/domain/QuestionTest.java
@@ -1,0 +1,28 @@
+package ppalatjyo.server.quiz.domain;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class QuestionTest {
+
+    @Test
+    @DisplayName("Question 생성")
+    void create() {
+        // given
+        String content = "content";
+        Answer answer1 = Answer.createAnswer("answer1");
+        Quiz quiz = Quiz.createQuiz("quiz");
+
+        // when
+        Question question = Question.create(quiz, content, answer1);
+
+        // then
+        assertThat(question.getContent()).isEqualTo(content);
+        assertThat(question.getAnswers()).containsExactly(answer1);
+        assertThat(question.getQuiz()).isEqualTo(quiz);
+        assertThat(quiz.getQuestions()).containsExactly(question);
+    }
+}

--- a/server/src/test/java/ppalatjyo/server/quiz/domain/QuestionTest.java
+++ b/server/src/test/java/ppalatjyo/server/quiz/domain/QuestionTest.java
@@ -3,6 +3,7 @@ package ppalatjyo.server.quiz.domain;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import ppalatjyo.server.user.domain.User;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -14,7 +15,8 @@ class QuestionTest {
         // given
         String content = "content";
         Answer answer1 = Answer.createAnswer("answer1");
-        Quiz quiz = Quiz.createQuiz("quiz");
+        User user = User.createMember("author", "<EMAIL>", "google");
+        Quiz quiz = Quiz.createQuiz("quiz", user);
 
         // when
         Question question = Question.create(quiz, content, answer1);

--- a/server/src/test/java/ppalatjyo/server/usergame/UserGameTest.java
+++ b/server/src/test/java/ppalatjyo/server/usergame/UserGameTest.java
@@ -1,0 +1,57 @@
+package ppalatjyo.server.usergame;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import ppalatjyo.server.game.Game;
+import ppalatjyo.server.lobby.domain.Lobby;
+import ppalatjyo.server.lobby.domain.LobbyOptions;
+import ppalatjyo.server.quiz.domain.Answer;
+import ppalatjyo.server.quiz.domain.Question;
+import ppalatjyo.server.quiz.domain.Quiz;
+import ppalatjyo.server.user.domain.User;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UserGameTest {
+
+    @Test
+    @DisplayName("UserGame 생성")
+    void join() {
+        // given
+        User user = User.createGuest("guest");
+        Lobby lobby = Lobby.createLobby("lobby", user, getQuiz(), LobbyOptions.defaultOptions());
+        Game game = Game.start(lobby);
+
+        // when
+        UserGame userGame = UserGame.join(user, game);
+
+        // then
+        assertThat(userGame.getUser()).isEqualTo(user);
+        assertThat(userGame.getGame()).isEqualTo(game);
+        assertThat(userGame.getScore()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("득점")
+    void score() {
+        // given
+        User user = User.createGuest("guest");
+        Lobby lobby = Lobby.createLobby("lobby", user, getQuiz(), LobbyOptions.defaultOptions());
+        Game game = Game.start(lobby);
+        UserGame userGame = UserGame.join(user, game);
+
+        // when
+        userGame.score();
+
+        // then
+        assertThat(userGame.getScore()).isEqualTo(1);
+    }
+
+    private Quiz getQuiz() {
+        Quiz quiz = Quiz.createQuiz("quiz", User.createMember("n", "e", "p"));
+        Question.create(quiz,"question1", Answer.createAnswer("answer1"));
+        Question.create(quiz, "question2", Answer.createAnswer("answer2"));
+        return quiz;
+    }
+}

--- a/server/src/test/java/ppalatjyo/server/usergame/UserGameTest.java
+++ b/server/src/test/java/ppalatjyo/server/usergame/UserGameTest.java
@@ -1,6 +1,5 @@
 package ppalatjyo.server.usergame;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import ppalatjyo.server.game.Game;

--- a/server/src/test/java/ppalatjyo/server/userlobby/UserLobbyTest.java
+++ b/server/src/test/java/ppalatjyo/server/userlobby/UserLobbyTest.java
@@ -1,4 +1,23 @@
+package ppalatjyo.server.userlobby;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import ppalatjyo.server.lobby.domain.Lobby;
+import ppalatjyo.server.user.domain.User;
+
 import static org.junit.jupiter.api.Assertions.*;
+
 class UserLobbyTest {
-  
+
+    @Test
+    @DisplayName("UserLobby 생성")
+    void createUserLobby() {
+        // given
+        User user = User.createGuest("user");
+        Lobby.createLobby("lobby", user, null, null);
+
+        // when
+
+        // then
+    }
 }

--- a/server/src/test/java/ppalatjyo/server/userlobby/UserLobbyTest.java
+++ b/server/src/test/java/ppalatjyo/server/userlobby/UserLobbyTest.java
@@ -1,0 +1,4 @@
+import static org.junit.jupiter.api.Assertions.*;
+class UserLobbyTest {
+  
+}

--- a/server/src/test/java/ppalatjyo/server/userlobby/UserLobbyTest.java
+++ b/server/src/test/java/ppalatjyo/server/userlobby/UserLobbyTest.java
@@ -15,7 +15,7 @@ class UserLobbyTest {
     void join() {
         // given
         User user = User.createGuest("user");
-        Lobby lobby = Lobby.createLobby("lobby", user, null, LobbyOptions.createDefaultOptions());
+        Lobby lobby = Lobby.createLobby("lobby", user, null, LobbyOptions.defaultOptions());
 
         // when
         UserLobby userLobby = UserLobby.join(user, lobby);
@@ -32,7 +32,7 @@ class UserLobbyTest {
     void leave() {
         // given
         User user = User.createGuest("user");
-        Lobby lobby = Lobby.createLobby("lobby", user, null, LobbyOptions.createDefaultOptions());
+        Lobby lobby = Lobby.createLobby("lobby", user, null, LobbyOptions.defaultOptions());
         UserLobby userLobby = UserLobby.join(user, lobby);
 
         // when

--- a/server/src/test/java/ppalatjyo/server/userlobby/UserLobbyTest.java
+++ b/server/src/test/java/ppalatjyo/server/userlobby/UserLobbyTest.java
@@ -3,21 +3,42 @@ package ppalatjyo.server.userlobby;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import ppalatjyo.server.lobby.domain.Lobby;
+import ppalatjyo.server.lobby.domain.LobbyOptions;
 import ppalatjyo.server.user.domain.User;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class UserLobbyTest {
 
     @Test
-    @DisplayName("UserLobby 생성")
-    void createUserLobby() {
+    @DisplayName("UserLobby 참가")
+    void join() {
         // given
         User user = User.createGuest("user");
-        Lobby.createLobby("lobby", user, null, null);
+        Lobby lobby = Lobby.createLobby("lobby", user, null, LobbyOptions.createDefaultOptions());
 
         // when
+        UserLobby userLobby = UserLobby.join(user, lobby);
 
         // then
+        assertThat(userLobby.getUser()).isEqualTo(user);
+        assertThat(userLobby.getLobby()).isEqualTo(lobby);
+        assertThat(userLobby.getJoinedAt()).isNotNull();
+        assertThat(userLobby.getLeftAt()).isNull();
+    }
+
+    @Test
+    @DisplayName("UserLobby 나가기")
+    void leave() {
+        // given
+        User user = User.createGuest("user");
+        Lobby lobby = Lobby.createLobby("lobby", user, null, LobbyOptions.createDefaultOptions());
+        UserLobby userLobby = UserLobby.join(user, lobby);
+
+        // when
+        userLobby.leave();
+
+        // then
+        assertThat(userLobby.getLeftAt()).isNotNull();
     }
 }

--- a/server/src/test/java/ppalatjyo/server/userlobby/UserLobbyTest.java
+++ b/server/src/test/java/ppalatjyo/server/userlobby/UserLobbyTest.java
@@ -39,6 +39,7 @@ class UserLobbyTest {
         userLobby.leave();
 
         // then
+        assertThat(userLobby.isLeft()).isTrue();
         assertThat(userLobby.getLeftAt()).isNotNull();
     }
 }


### PR DESCRIPTION
## 관련 이슈
- #14 

## 변경 사항
- 다음 엔티티를 추가하고 테스트를 작성하였습니다:
  - User
  - Lobby
  - UserLobby
  - Game
  - GameEvent
  - UserGame
  - Message
  - Quiz
  - Question
  - Answer
- 엔티티는 다음 컨벤션을 따랐습니다:
  - 생성자와 빌더를 노출하지 않고 펙토리 생성 메서드만 공개하였습니다.
  - 영향을 받는 엔티티를 기준으로 도메인 메서드를 구현하였습니다.
    - 예를 들어 User가 Lobby를 생성하는 경우, 영향을 받는 데이터는 Lobby이기 때문에(DB의 lobby 테이블에 튜플 추가) 메서드를 해당 엔티티에 추가.
    - 예시)
    ```java
    // User가 Lobby 생성 -> Lobby
    Lobby lobby = Lobby.create(user) ;
    
    // User가 Lobby에 참가 -> UserLobby
    UserLobby userLobby = UserLobby.join(user, lobby);
    ```
  - 엔티티에 Setter를 사용하지 않았습니다.
  - 엔티티 내부에서 인스턴스 생성은 `@Builder`를 사용하도록 통일하였습니다.
  - 모든 엔티티는 JPA Auditing을 위해 BaseEntity를 상속 받았습니다.
    - Auditing을 위한 필드는 비즈니스 로직에 사용하지 않았습니다.
  - 모든 예외는 도메인별 커스텀 예외로 정의하였습니다.
  - 모든 엔티티 메서드에 테스트를 작성하였습니다.

## 고려 사항
- JPA 내부 로직을 고려하지 않고, 엔티티 사이 연관관계를 적극적으로 활용해 구현하였습니다. -> 이후 쿼리 최적화에 주의해야 합니다.