### PR TITLE
[REFACTOR #28]: 인증 예외가 지나치게 구체적인 문제

### DIFF
--- a/server/src/main/java/ppalatjyo/server/global/dto/ResponseDto.java
+++ b/server/src/main/java/ppalatjyo/server/global/dto/ResponseDto.java
@@ -11,36 +11,32 @@ import ppalatjyo.server.global.dto.error.ResponseErrorDto;
 public class ResponseDto<T> {
     private final boolean success;
     private final int status;
-    private final String message;
     private T data;
     private ResponseErrorDto error;
 
-    public static <T> ResponseEntity<ResponseDto<T>> ok(String message, T data) {
+    public static <T> ResponseEntity<ResponseDto<T>> ok(T data) {
         ResponseDto<T> responseDto = ResponseDto.<T>builder()
                 .success(true)
                 .status(HttpStatus.OK.value())
-                .message(message)
                 .data(data)
                 .build();
 
         return ResponseEntity.ok(responseDto);
     }
 
-    public static ResponseEntity<ResponseDto<Void>> ok(String message) {
+    public static ResponseEntity<ResponseDto<Void>> ok() {
         ResponseDto<Void> dto = ResponseDto.<Void>builder()
                 .success(true)
                 .status(HttpStatus.OK.value())
-                .message(message)
                 .build();
 
         return ResponseEntity.ok(dto);
     }
 
-    public static ResponseEntity<ResponseDto<Void>> error(HttpStatus status, String message, ResponseErrorDto errorDto) {
+    public static ResponseEntity<ResponseDto<Void>> error(HttpStatus status, ResponseErrorDto errorDto) {
         ResponseDto<Void> dto = ResponseDto.<Void>builder()
                 .success(false)
                 .status(status.value())
-                .message(message)
                 .error(errorDto)
                 .build();
 

--- a/server/src/main/java/ppalatjyo/server/global/dto/ResponseDtoTestController.java
+++ b/server/src/main/java/ppalatjyo/server/global/dto/ResponseDtoTestController.java
@@ -9,6 +9,6 @@ public class ResponseDtoTestController {
 
     @GetMapping("/test/response/ok")
     public ResponseEntity<ResponseDto<Void>> testOk() {
-        return ResponseDto.ok("ok.");
+        return ResponseDto.ok();
     }
 }

--- a/server/src/main/java/ppalatjyo/server/global/dto/error/ResponseErrorDto.java
+++ b/server/src/main/java/ppalatjyo/server/global/dto/error/ResponseErrorDto.java
@@ -26,7 +26,7 @@ public class ResponseErrorDto {
 
     public static ResponseErrorDto validationError(String path, Map<String, FieldErrorDto> data) {
         return ResponseErrorDto.builder()
-                .message("Validation Error")
+                .message("Validation Error.")
                 .path(path)
                 .timestamp(LocalDateTime.now())
                 .data(data)

--- a/server/src/main/java/ppalatjyo/server/global/security/jwt/JwtAuthenticationFilter.java
+++ b/server/src/main/java/ppalatjyo/server/global/security/jwt/JwtAuthenticationFilter.java
@@ -54,12 +54,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     }
 
     private void onUnsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, Exception ex) throws IOException {
-        log.info("Authentication Failed", ex);
+        log.debug("Authentication Failed", ex);
 
-        String message = "Authentication Failed";
+        String errorMessage = "Authentication Failed.";
         HttpStatus status = HttpStatus.UNAUTHORIZED;
-        ResponseErrorDto errorDto = ResponseErrorDto.commonError(ex.getMessage(), request.getRequestURI());
-        ResponseDto<Void> responseDto = ResponseDto.error(status, message, errorDto).getBody();
+        ResponseErrorDto errorDto = ResponseErrorDto.commonError(errorMessage, request.getRequestURI());
+        ResponseDto<Void> responseDto = ResponseDto.error(status, errorDto).getBody();
 
         response.setStatus(status.value());
         response.setContentType("application/json");

--- a/server/src/main/java/ppalatjyo/server/global/validation/MethodArgumentNotValidExceptionHandler.java
+++ b/server/src/main/java/ppalatjyo/server/global/validation/MethodArgumentNotValidExceptionHandler.java
@@ -29,6 +29,6 @@ public class MethodArgumentNotValidExceptionHandler {
 
         ResponseErrorDto responseErrorDto = ResponseErrorDto.validationError(request.getRequestURI(), errorMap);
 
-        return ResponseDto.error(HttpStatus.BAD_REQUEST, "Validation Error", responseErrorDto);
+        return ResponseDto.error(HttpStatus.BAD_REQUEST, responseErrorDto);
     }
 }

--- a/server/src/main/java/ppalatjyo/server/global/validation/ValidationTestController.java
+++ b/server/src/main/java/ppalatjyo/server/global/validation/ValidationTestController.java
@@ -12,6 +12,6 @@ public class ValidationTestController {
 
     @PostMapping("/test/validation")
     public ResponseEntity<ResponseDto<Void>> validation(@RequestBody @Valid ValidationTestRequestDto requestDto) {
-        return ResponseDto.ok("ok.");
+        return ResponseDto.ok();
     }
 }

--- a/server/src/main/resources/static/docs/index.html
+++ b/server/src/main/resources/static/docs/index.html
@@ -576,7 +576,6 @@ Host: localhost:8080
 <pre class="highlight nowrap"><code class="language-json" data-lang="json">{
   "success" : true,
   "status" : 200,
-  "message" : "ok.",
   "data" : null,
   "error" : null
 }</code></pre>
@@ -588,24 +587,23 @@ Host: localhost:8080
 <pre class="highlight nowrap"><code class="language-json" data-lang="json">{
   "success" : false,
   "status" : 400,
-  "message" : "Validation Error",
   "data" : null,
   "error" : {
-    "message" : "Validation Error",
+    "message" : "Validation Error.",
     "path" : "/test/validation",
-    "timestamp" : "2025-06-16T11:32:53.0982791",
+    "timestamp" : "2025-06-17T16:19:58.4358769",
     "data" : {
       "quantity" : {
         "rejectedValue" : 2000,
         "message" : "주문 수량은 한 번에 최대 999개 입니다."
       },
-      "phone" : {
-        "rejectedValue" : "123",
-        "message" : "전화번호는 10자 이상 15자 이하여야 합니다."
-      },
       "tags[0]" : {
         "rejectedValue" : "",
         "message" : "태그는 빈 값일 수 없습니다."
+      },
+      "phone" : {
+        "rejectedValue" : "123",
+        "message" : "전화번호는 10자 이상 15자 이하여야 합니다."
       },
       "name" : {
         "rejectedValue" : "",
@@ -647,11 +645,6 @@ Host: localhost:8080
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>status</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">HTTP 상태 코드</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">결과 메시지</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>error.message</code></p></td>

--- a/server/src/test/java/ppalatjyo/server/global/dto/ResponseDtoTest.java
+++ b/server/src/test/java/ppalatjyo/server/global/dto/ResponseDtoTest.java
@@ -18,7 +18,7 @@ class ResponseDtoTest {
         String message = "Okay.";
 
         // when
-        ResponseEntity<ResponseDto<Void>> response = ResponseDto.ok(message);
+        ResponseEntity<ResponseDto<Void>> response = ResponseDto.ok();
 
         // then
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
@@ -26,7 +26,6 @@ class ResponseDtoTest {
         assertThat(response.getBody()).isInstanceOf(ResponseDto.class);
         assertThat(response.getBody().isSuccess()).isTrue();
         assertThat(response.getBody().getStatus()).isEqualTo(HttpStatus.OK.value());
-        assertThat(response.getBody().getMessage()).isEqualTo(message);
         assertThat(response.getBody().getData()).isNull();
         assertThat(response.getBody().getError()).isNull();
     }
@@ -40,7 +39,7 @@ class ResponseDtoTest {
         TestResponseDto dataDto = new TestResponseDto(content);
 
         // when
-        ResponseEntity<ResponseDto<TestResponseDto>> response = ResponseDto.ok(message, dataDto);
+        ResponseEntity<ResponseDto<TestResponseDto>> response = ResponseDto.ok(dataDto);
 
         // then
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
@@ -48,7 +47,6 @@ class ResponseDtoTest {
         assertThat(response.getBody()).isInstanceOf(ResponseDto.class);
         assertThat(response.getBody().isSuccess()).isTrue();
         assertThat(response.getBody().getStatus()).isEqualTo(HttpStatus.OK.value());
-        assertThat(response.getBody().getMessage()).isEqualTo(message);
         assertThat(response.getBody().getError()).isNull();
 
         assertThat(response.getBody().getData()).isNotNull();

--- a/server/src/test/java/ppalatjyo/server/global/validation/ValidationTestControllerTest.java
+++ b/server/src/test/java/ppalatjyo/server/global/validation/ValidationTestControllerTest.java
@@ -80,7 +80,6 @@ class ValidationTestControllerTest {
                         responseFields(
                                 fieldWithPath("success").description("성공 여부"),
                                 fieldWithPath("status").description("HTTP 상태 코드"),
-                                fieldWithPath("message").description("결과 메시지"),
                                 fieldWithPath("error.message").description("에러 메시지"),
                                 fieldWithPath("error.path").description("요청 경로"),
                                 fieldWithPath("error.timestamp").description("에러 발생 시간"),


### PR DESCRIPTION
## 관련 이슈
#28 

## 변경 사항
- JwtAuthentication Filter에서 예외 발생시 응답 받는 에러 메시지를 "Authentication Failed." 로 통일하였습니다.
- ResponseDto에서 message 제거하였습니다. -> ResponseErrorDto의 message와 중복, 메시지가 필요한 경우가 에러가 난 경우라 생각하여 error에만 두기로 결정하였습니다.
- 관련 코드 및 테스트를 수정하였습니다.

## 스크린샷

<img width="803" alt="image" src="https://github.com/user-attachments/assets/9226f6a2-7861-468d-b84e-8e306cc44e6b" />