### PR TITLE
[REFACTOR #40]: Spring Security 구현 구조 개선

### DIFF
--- a/server/src/main/java/ppalatjyo/server/global/security/SecurityConfig.java
+++ b/server/src/main/java/ppalatjyo/server/global/security/SecurityConfig.java
@@ -1,9 +1,11 @@
 package ppalatjyo.server.global.security;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
-import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.ProviderManager;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -13,16 +15,15 @@ import org.springframework.security.web.authentication.logout.LogoutFilter;
 import ppalatjyo.server.global.security.handler.CustomAccessDeniedHandler;
 import ppalatjyo.server.global.security.handler.CustomAuthenticationEntryPoint;
 import ppalatjyo.server.global.security.jwt.JwtAuthenticationFilter;
-
-import java.util.List;
+import ppalatjyo.server.global.security.jwt.JwtAuthenticationProvider;
 
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
 
-    private final JwtAuthenticationFilter jwtAuthenticationFilter;
-    private final PermittedUrlChecker permittedUrlChecker;
+    private final JwtAuthenticationProvider jwtAuthenticationProvider;
+    private final ObjectMapper objectMapper;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -31,28 +32,35 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
+                                "/favicon.ico",
+                                "/error",
                                 "/test/**",
                                 "/docs/**",
                                 "/api/auth/**"
                         ).permitAll()
                         .anyRequest().authenticated()
                 )
-                .addFilterAfter(jwtAuthenticationFilter, LogoutFilter.class)
+                .addFilterAfter(jwtAuthenticationFilter(), LogoutFilter.class)
                 .exceptionHandling(configurer -> configurer
-                                .authenticationEntryPoint(new CustomAuthenticationEntryPoint())
-                                .accessDeniedHandler(new CustomAccessDeniedHandler())
+                        .authenticationEntryPoint(new CustomAuthenticationEntryPoint(objectMapper))
+                        .accessDeniedHandler(new CustomAccessDeniedHandler(objectMapper))
                 )
                 .build();
     }
 
     /**
-     *  <p> JwtAuthenticationFilter가 두 번 등록되는 것을 방지
-     *  <p> <a href="https://docs.spring.io/spring-security/reference/servlet/architecture.html#adding-custom-filter">Spring Security 공식 문서</a>
+     * 주어진 AuthenticationProvider 리스트를 순회해 지원하는 인증 처리를 제공
      */
     @Bean
-    public FilterRegistrationBean<JwtAuthenticationFilter> jwtAuthenticationFilterFilterRegistration(JwtAuthenticationFilter filter) {
-        FilterRegistrationBean<JwtAuthenticationFilter> registration = new FilterRegistrationBean<>(filter);
-        registration.setEnabled(false);
-        return registration;
+    public AuthenticationManager authenticationManager() {
+        return new ProviderManager(jwtAuthenticationProvider);
+    }
+
+    /**
+     * JWT 토큰으로 인증을 제공하는 필터
+     */
+    @Bean
+    public JwtAuthenticationFilter jwtAuthenticationFilter() {
+        return new JwtAuthenticationFilter(authenticationManager());
     }
 }

--- a/server/src/main/java/ppalatjyo/server/global/security/SecurityConfig.java
+++ b/server/src/main/java/ppalatjyo/server/global/security/SecurityConfig.java
@@ -9,8 +9,9 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.authentication.logout.LogoutFilter;
+import ppalatjyo.server.global.security.handler.CustomAccessDeniedHandler;
+import ppalatjyo.server.global.security.handler.CustomAuthenticationEntryPoint;
 import ppalatjyo.server.global.security.jwt.JwtAuthenticationFilter;
 
 import java.util.List;
@@ -27,12 +28,20 @@ public class SecurityConfig {
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         return http
                 .csrf(AbstractHttpConfigurer::disable)
-                .sessionManagement((session) -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers(permittedUrlChecker.toArray()).permitAll()
+                        .requestMatchers(
+                                "/test/**",
+                                "/docs/**",
+                                "/api/auth/**"
+                        ).permitAll()
                         .anyRequest().authenticated()
                 )
-                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterAfter(jwtAuthenticationFilter, LogoutFilter.class)
+                .exceptionHandling(configurer -> configurer
+                                .authenticationEntryPoint(new CustomAuthenticationEntryPoint())
+                                .accessDeniedHandler(new CustomAccessDeniedHandler())
+                )
                 .build();
     }
 

--- a/server/src/main/java/ppalatjyo/server/global/security/exception/InvalidAuthorizationHeaderException.java
+++ b/server/src/main/java/ppalatjyo/server/global/security/exception/InvalidAuthorizationHeaderException.java
@@ -1,6 +1,8 @@
 package ppalatjyo.server.global.security.exception;
 
-public class InvalidAuthorizationHeaderException extends RuntimeException {
+import org.springframework.security.core.AuthenticationException;
+
+public class InvalidAuthorizationHeaderException extends AuthenticationException {
     public InvalidAuthorizationHeaderException(String message) {
         super(message);
     }

--- a/server/src/main/java/ppalatjyo/server/global/security/exception/JwtValidationException.java
+++ b/server/src/main/java/ppalatjyo/server/global/security/exception/JwtValidationException.java
@@ -1,6 +1,8 @@
 package ppalatjyo.server.global.security.exception;
 
-public class JwtValidationException extends RuntimeException {
+import org.springframework.security.core.AuthenticationException;
+
+public class JwtValidationException extends AuthenticationException {
     public JwtValidationException(String message) {
         super(message);
     }

--- a/server/src/main/java/ppalatjyo/server/global/security/handler/CustomAccessDeniedHandler.java
+++ b/server/src/main/java/ppalatjyo/server/global/security/handler/CustomAccessDeniedHandler.java
@@ -1,0 +1,16 @@
+package ppalatjyo.server.global.security.handler;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+
+import java.io.IOException;
+
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+
+    }
+}

--- a/server/src/main/java/ppalatjyo/server/global/security/handler/CustomAccessDeniedHandler.java
+++ b/server/src/main/java/ppalatjyo/server/global/security/handler/CustomAccessDeniedHandler.java
@@ -1,16 +1,37 @@
 package ppalatjyo.server.global.security.handler;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.web.access.AccessDeniedHandler;
+import ppalatjyo.server.global.dto.ResponseDto;
+import ppalatjyo.server.global.dto.error.ResponseErrorDto;
 
 import java.io.IOException;
 
+@Slf4j
+@RequiredArgsConstructor
 public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
+
     @Override
     public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        log.debug("Authentication Failed", accessDeniedException);
 
+        String errorMessage = "Authentication Failed.";
+        HttpStatus status = HttpStatus.UNAUTHORIZED;
+        ResponseErrorDto errorDto = ResponseErrorDto.commonError(errorMessage, request.getRequestURI());
+        ResponseDto<Void> responseDto = ResponseDto.error(status, errorDto).getBody();
+
+        response.setStatus(status.value());
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        objectMapper.writeValue(response.getWriter(), responseDto);
     }
 }

--- a/server/src/main/java/ppalatjyo/server/global/security/handler/CustomAuthenticationEntryPoint.java
+++ b/server/src/main/java/ppalatjyo/server/global/security/handler/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,16 @@
+package ppalatjyo.server.global.security.handler;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+import java.io.IOException;
+
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+
+    }
+}

--- a/server/src/main/java/ppalatjyo/server/global/security/handler/CustomAuthenticationEntryPoint.java
+++ b/server/src/main/java/ppalatjyo/server/global/security/handler/CustomAuthenticationEntryPoint.java
@@ -1,16 +1,36 @@
 package ppalatjyo.server.global.security.handler;
 
-import jakarta.servlet.ServletException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
+import ppalatjyo.server.global.dto.ResponseDto;
+import ppalatjyo.server.global.dto.error.ResponseErrorDto;
 
 import java.io.IOException;
 
+@Slf4j
+@RequiredArgsConstructor
 public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
-    @Override
-    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
 
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
+        log.debug("Authentication Failed", authException);
+
+        String errorMessage = "Authentication Failed.";
+        HttpStatus status = HttpStatus.UNAUTHORIZED;
+        ResponseErrorDto errorDto = ResponseErrorDto.commonError(errorMessage, request.getRequestURI());
+        ResponseDto<Void> responseDto = ResponseDto.error(status, errorDto).getBody();
+
+        response.setStatus(status.value());
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        objectMapper.writeValue(response.getWriter(), responseDto);
     }
 }

--- a/server/src/main/java/ppalatjyo/server/global/security/jwt/JwtAuthenticationConverter.java
+++ b/server/src/main/java/ppalatjyo/server/global/security/jwt/JwtAuthenticationConverter.java
@@ -13,15 +13,13 @@ public class JwtAuthenticationConverter implements AuthenticationConverter {
     @Override
     public JwtAuthenticationToken convert(HttpServletRequest request) {
         String authorizationHeader = request.getHeader("Authorization");
-        if (authorizationHeader == null) {
-            throw new InvalidAuthorizationHeaderException("No authorization header found");
-        } else if (!authorizationHeader.startsWith("Bearer ")) {
-            throw new InvalidAuthorizationHeaderException("Authorization header should start with 'Bearer'");
+        if (authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
+            return null;
         }
 
         String token = authorizationHeader.substring(7);
         if (token.isEmpty()) {
-            throw new InvalidAuthorizationHeaderException("Token is not provided after 'Bearer'");
+            return null;
         }
 
         return JwtAuthenticationToken.unauthenticated(token);

--- a/server/src/main/java/ppalatjyo/server/global/security/jwt/JwtAuthenticationFilter.java
+++ b/server/src/main/java/ppalatjyo/server/global/security/jwt/JwtAuthenticationFilter.java
@@ -20,50 +20,28 @@ import ppalatjyo.server.global.security.PermittedUrlChecker;
 
 import java.io.IOException;
 
-@Component
 @RequiredArgsConstructor
 @Slf4j
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
-    private final AuthenticationConverter authenticationConverter;
+    private final AuthenticationConverter authenticationConverter = new JwtAuthenticationConverter();
     private final AuthenticationManager authenticationManager;
-    private final ObjectMapper objectMapper;
-    private final PermittedUrlChecker permittedUrlChecker;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
-        if (permittedUrlChecker.isPermitted(request.getRequestURI())) {
+        Authentication authenticationRequest = authenticationConverter.convert(request);
+        if (authenticationRequest == null) {
             filterChain.doFilter(request, response);
             return;
         }
 
-        try {
-            Authentication authenticationRequest = authenticationConverter.convert(request);
-            Authentication authenticationResult = authenticationManager.authenticate(authenticationRequest);
-
-            onSuccessfulAuthentication(request, response, authenticationResult);
-
+        Authentication authenticationResult = authenticationManager.authenticate(authenticationRequest);
+        if (authenticationResult == null) {
             filterChain.doFilter(request, response);
-        } catch (Exception e) {
-            onUnsuccessfulAuthentication(request, response, e);
+            return;
         }
-    }
 
-    private void onSuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, Authentication authenticationResult) {
         SecurityContextHolder.getContext().setAuthentication(authenticationResult);
-    }
-
-    private void onUnsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, Exception ex) throws IOException {
-        log.debug("Authentication Failed", ex);
-
-        String errorMessage = "Authentication Failed.";
-        HttpStatus status = HttpStatus.UNAUTHORIZED;
-        ResponseErrorDto errorDto = ResponseErrorDto.commonError(errorMessage, request.getRequestURI());
-        ResponseDto<Void> responseDto = ResponseDto.error(status, errorDto).getBody();
-
-        response.setStatus(status.value());
-        response.setContentType("application/json");
-        response.setCharacterEncoding("UTF-8");
-        objectMapper.writeValue(response.getWriter(), responseDto);
+        filterChain.doFilter(request, response);
     }
 }

--- a/server/src/main/java/ppalatjyo/server/global/security/jwt/JwtAuthenticationProvider.java
+++ b/server/src/main/java/ppalatjyo/server/global/security/jwt/JwtAuthenticationProvider.java
@@ -5,7 +5,7 @@ import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.security.SignatureException;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -15,10 +15,10 @@ import ppalatjyo.server.global.security.exception.JwtValidationException;
 
 @Component
 @RequiredArgsConstructor
-public class JwtAuthenticationManager implements AuthenticationManager {
+public class JwtAuthenticationProvider implements AuthenticationProvider {
 
-    private final JwtTokenProvider jwtTokenProvider;
     private final UserDetailsService userDetailsService;
+    private final JwtTokenProvider jwtTokenProvider;
 
     @Override
     public Authentication authenticate(Authentication authentication) throws AuthenticationException {
@@ -34,7 +34,7 @@ public class JwtAuthenticationManager implements AuthenticationManager {
                     userDetails,
                     token,
                     userDetails.getAuthorities());
-        } catch (ExpiredJwtException e) {
+        } catch (ExpiredJwtException e) { // JwtException을 AuthenticationException 으로 변환
             throw new JwtValidationException("Token has expired");
         } catch (MalformedJwtException e) {
             throw new JwtValidationException("Token is invalid");
@@ -44,8 +44,11 @@ public class JwtAuthenticationManager implements AuthenticationManager {
             throw new JwtValidationException("Unsupported token");
         } catch (IllegalArgumentException e) {
             throw new JwtValidationException("Invalid JWT token");
-        } catch (Exception e) {
-            throw new JwtValidationException("Unexpected JWT token Exception");
         }
+    }
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return JwtAuthenticationToken.class.isAssignableFrom(authentication);
     }
 }


### PR DESCRIPTION
## 관련 이슈
#40 

## 변경 사항
- `JwtAuthenticationManager`를 삭제하고 `ProviderManager`를 `AuthenticationManager` 빈으로 등록했습니다.
- `JwtAuthenticationProvider`를 구현하여 `ProvderManager`에 매개변수로 전달하였습니다. 
- `JwtAuthenticationFilter`는 `AuthenticationConverter`를 통해 빈 인증을 생성하고, `AuthenticationManager`로 인증하며, 이를 SecurityContext에 저장하도록 구현하였습니다.
- `JwtAuthenticationFilter`에서 `JwtAuthenticationConverter`를 직접 멤버 필드로 초기화하도록 수정하였습니다.
- `JwtAuthenticationConverter`가 헤더나 토큰을 읽을 수 없을 경우 예외를 던지는 것이 아닌 null을 반환하도록 수정하였습니다.
- `AuthenticationEntryPoint`를 구현해 인증 예외에 대한 공통 응답을 반환하도록 하였습니다.
- `AccessDeniedHandler`를 구현해 인증 예외에 대한 공통 응답을 반환하도록 하였습니다.
- `PermittedUrlsChecker`를 삭제하였습니다.

## 추가 정보

- [Spring Security 구조의 의도 파악을 위해 전체 흐름을 직접 정리한 글](https://velog.io/@gyehyunbak/Spring-Security-%EC%95%84%ED%82%A4%ED%85%8D%EC%B2%98%EC%97%90-%EB%A7%9E%EA%B2%8C-%EC%9D%B8%EC%A6%9D%EC%9D%B8%EA%B0%80-%EB%A1%9C%EC%A7%81-%EA%B0%9C%EC%84%A0%ED%95%98%EA%B8%B0)