### PR TITLE
[FEATURE #33]: UserLobbyService 구현 

### DIFF
--- a/server/src/main/java/ppalatjyo/server/lobby/domain/Lobby.java
+++ b/server/src/main/java/ppalatjyo/server/lobby/domain/Lobby.java
@@ -6,8 +6,11 @@ import ppalatjyo.server.global.audit.BaseEntity;
 import ppalatjyo.server.lobby.LobbyAlreadyDeletedException;
 import ppalatjyo.server.quiz.domain.Quiz;
 import ppalatjyo.server.user.domain.User;
+import ppalatjyo.server.userlobby.UserLobby;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -35,13 +38,22 @@ public class Lobby extends BaseEntity {
     @JoinColumn(name = "quiz_id")
     private Quiz quiz;
 
+    @OneToMany(mappedBy = "lobby", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<UserLobby> userLobbies = new ArrayList<>();
+
     public static Lobby createLobby(String name, User host, Quiz quiz, LobbyOptions options) {
-        return Lobby.builder()
+        Lobby lobby = Lobby.builder()
                 .name(name)
                 .host(host)
                 .quiz(quiz)
+                .userLobbies(new ArrayList<>())
                 .options(options)
                 .build();
+
+        UserLobby userLobby = UserLobby.join(host, lobby);
+        lobby.userLobbies.add(userLobby);
+
+        return lobby;
     }
 
     public void delete() {

--- a/server/src/main/java/ppalatjyo/server/userlobby/UserLobbyRepository.java
+++ b/server/src/main/java/ppalatjyo/server/userlobby/UserLobbyRepository.java
@@ -1,0 +1,9 @@
+package ppalatjyo.server.userlobby;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserLobbyRepository extends JpaRepository<UserLobby, Long> {
+    Optional<UserLobby> findByUserIdAndLobbyId(Long userId, Long lobbyId);
+}

--- a/server/src/main/java/ppalatjyo/server/userlobby/UserLobbyService.java
+++ b/server/src/main/java/ppalatjyo/server/userlobby/UserLobbyService.java
@@ -1,0 +1,11 @@
+package ppalatjyo.server.userlobby;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserLobbyService {
+
+
+}

--- a/server/src/main/java/ppalatjyo/server/userlobby/UserLobbyService.java
+++ b/server/src/main/java/ppalatjyo/server/userlobby/UserLobbyService.java
@@ -2,10 +2,32 @@ package ppalatjyo.server.userlobby;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import ppalatjyo.server.lobby.LobbyRepository;
+import ppalatjyo.server.lobby.domain.Lobby;
+import ppalatjyo.server.user.UserRepository;
+import ppalatjyo.server.user.domain.User;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class UserLobbyService {
 
+    private final UserRepository userRepository;
+    private final LobbyRepository lobbyRepository;
+    private final UserLobbyRepository userLobbyRepository;
 
+    public void join(Long userId, Long lobbyId) { // TODO: 참가 메시지 전송
+        User user = userRepository.findById(userId).orElseThrow();
+        Lobby lobby = lobbyRepository.findById(lobbyId).orElseThrow();
+
+        UserLobby userLobby = UserLobby.join(user, lobby);
+
+        userLobbyRepository.save(userLobby);
+    }
+
+    public void leave(Long userId, Long lobbyId) { // TODO: 퇴장 메시지 전송
+        UserLobby userLobby = userLobbyRepository.findByUserIdAndLobbyId(userId, lobbyId).orElseThrow();
+        userLobby.leave();
+    }
 }

--- a/server/src/test/java/ppalatjyo/server/lobby/LobbyServiceTest.java
+++ b/server/src/test/java/ppalatjyo/server/lobby/LobbyServiceTest.java
@@ -62,6 +62,7 @@ class LobbyServiceTest {
         Lobby createdLobby = captor.getValue();
         assertThat(createdLobby.getName()).isEqualTo(name);
         assertThat(createdLobby.getHost()).isEqualTo(host);
+        assertThat(createdLobby.getUserLobbies().size()).isEqualTo(1);
         assertThat(createdLobby.getQuiz()).isEqualTo(quiz);
         assertThat(createdLobby.getOptions().getMaxUsers()).isEqualTo(maxUsers);
     }

--- a/server/src/test/java/ppalatjyo/server/lobby/LobbyTest.java
+++ b/server/src/test/java/ppalatjyo/server/lobby/LobbyTest.java
@@ -35,6 +35,7 @@ class LobbyTest {
         assertThat(lobby.getOptions().getMaxUsers()).isEqualTo(maxUsers);
         assertThat(lobby.getOptions().getMinPerGame()).isEqualTo(minPerGame);
         assertThat(lobby.getOptions().getSecPerQuestion()).isEqualTo(secPerQuestion);
+        assertThat(lobby.getUserLobbies().size()).isEqualTo(1);
     }
 
     @Test

--- a/server/src/test/java/ppalatjyo/server/userlobby/UserLobbyServiceTest.java
+++ b/server/src/test/java/ppalatjyo/server/userlobby/UserLobbyServiceTest.java
@@ -1,19 +1,42 @@
 package ppalatjyo.server.userlobby;
 
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.transaction.annotation.Transactional;
+import ppalatjyo.server.lobby.LobbyRepository;
 import ppalatjyo.server.lobby.domain.Lobby;
+import ppalatjyo.server.lobby.domain.LobbyOptions;
+import ppalatjyo.server.quiz.domain.Quiz;
+import ppalatjyo.server.user.UserRepository;
 import ppalatjyo.server.user.domain.User;
 
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 @Transactional
 class UserLobbyServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private LobbyRepository lobbyRepository;
+
+    @Mock
+    private UserLobbyRepository userLobbyRepository;
 
     @InjectMocks
     private UserLobbyService userLobbyService;
@@ -22,11 +45,49 @@ class UserLobbyServiceTest {
     @DisplayName("User가 Lobby에 참가")
     void join() {
         // given
+        Long userId = 1L;
+        Long lobbyId = 1L;
+
+        User host = User.createMember("host", "email", "provider");
+        Lobby lobby = Lobby.createLobby("lobby", host, Quiz.createQuiz("quiz", host), LobbyOptions.defaultOptions());
         User user = User.createGuest("user");
-//        Lobby lobby = Lobby.createLobby("lobby", );
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(lobbyRepository.findById(lobbyId)).thenReturn(Optional.of(lobby));
 
         // when
+        userLobbyService.join(userId, lobbyId);
 
         // then
+        ArgumentCaptor<UserLobby> captor = ArgumentCaptor.forClass(UserLobby.class);
+        verify(userLobbyRepository, times(1)).save(captor.capture());
+
+        UserLobby userLobby = captor.getValue();
+
+        assertThat(userLobby.getUser()).isEqualTo(user);
+        assertThat(userLobby.getLobby()).isEqualTo(lobby);
+        assertThat(userLobby.getJoinedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("User가 Lobby에서 나감")
+    void leave() {
+        // given
+        Long userId = 1L;
+        Long lobbyId = 1L;
+
+        User host = User.createMember("host", "email", "provider");
+        Lobby lobby = Lobby.createLobby("lobby", host, Quiz.createQuiz("quiz", host), LobbyOptions.defaultOptions());
+        User user = User.createGuest("user");
+
+        UserLobby userLobby = UserLobby.join(user, lobby);
+
+        when(userLobbyRepository.findByUserIdAndLobbyId(userId, lobbyId)).thenReturn(Optional.of(userLobby));
+
+        // when
+        userLobbyService.leave(userId, lobbyId);
+
+        // then
+        assertThat(userLobby.isLeft()).isTrue();
     }
 }

--- a/server/src/test/java/ppalatjyo/server/userlobby/UserLobbyServiceTest.java
+++ b/server/src/test/java/ppalatjyo/server/userlobby/UserLobbyServiceTest.java
@@ -1,0 +1,32 @@
+package ppalatjyo.server.userlobby;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.annotation.Transactional;
+import ppalatjyo.server.lobby.domain.Lobby;
+import ppalatjyo.server.user.domain.User;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+@Transactional
+class UserLobbyServiceTest {
+
+    @InjectMocks
+    private UserLobbyService userLobbyService;
+
+    @Test
+    @DisplayName("User가 Lobby에 참가")
+    void join() {
+        // given
+        User user = User.createGuest("user");
+//        Lobby lobby = Lobby.createLobby("lobby", );
+
+        // when
+
+        // then
+    }
+}


### PR DESCRIPTION
## 관련 이슈

- #33 

## 변경 사항

- Lobby 생성 시, Host에 대한 UserLobby가 자동 추가되도록 수정하였습니다. (CascadeType.ALL로 영속될 때 함께 추가되도록 합니다)
- UserLobbyService를 구현하였습니다.
  - 참가, 퇴장
- 관련 테스트를 작성하였습니다.

## 고려 사항

- 아직 입장/퇴장 시 메시지 발행 로직이 추가 되지 않았습니다. -> MessageService와 함께 구현 필요.