### PR TITLE
[FEATURE #38]: MessageService 구현

### DIFF
--- a/server/src/main/java/ppalatjyo/server/game/GameService.java
+++ b/server/src/main/java/ppalatjyo/server/game/GameService.java
@@ -8,7 +8,7 @@ import ppalatjyo.server.game.dto.SubmitAnswerRequestDto;
 import ppalatjyo.server.gameevent.GameEventService;
 import ppalatjyo.server.lobby.LobbyRepository;
 import ppalatjyo.server.lobby.domain.Lobby;
-import ppalatjyo.server.message.Message;
+import ppalatjyo.server.message.domain.Message;
 import ppalatjyo.server.message.MessageRepository;
 import ppalatjyo.server.usergame.UserGame;
 import ppalatjyo.server.usergame.UserGameRepository;

--- a/server/src/main/java/ppalatjyo/server/gameevent/GameEventService.java
+++ b/server/src/main/java/ppalatjyo/server/gameevent/GameEventService.java
@@ -6,7 +6,7 @@ import org.springframework.transaction.annotation.Transactional;
 import ppalatjyo.server.game.GameRepository;
 import ppalatjyo.server.game.domain.Game;
 import ppalatjyo.server.gameevent.domain.GameEvent;
-import ppalatjyo.server.message.Message;
+import ppalatjyo.server.message.domain.Message;
 import ppalatjyo.server.message.MessageRepository;
 import ppalatjyo.server.usergame.UserGame;
 import ppalatjyo.server.usergame.UserGameRepository;

--- a/server/src/main/java/ppalatjyo/server/gameevent/domain/GameEvent.java
+++ b/server/src/main/java/ppalatjyo/server/gameevent/domain/GameEvent.java
@@ -4,7 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import ppalatjyo.server.game.domain.Game;
 import ppalatjyo.server.global.audit.BaseEntity;
-import ppalatjyo.server.message.Message;
+import ppalatjyo.server.message.domain.Message;
 import ppalatjyo.server.quiz.domain.Question;
 import ppalatjyo.server.usergame.UserGame;
 

--- a/server/src/main/java/ppalatjyo/server/message/MessageEventHandler.java
+++ b/server/src/main/java/ppalatjyo/server/message/MessageEventHandler.java
@@ -1,0 +1,21 @@
+package ppalatjyo.server.message;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+import ppalatjyo.server.message.event.ChatMessageSentEvent;
+import ppalatjyo.server.message.event.SystemMessageSentEvent;
+
+@Component
+public class MessageEventHandler {
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleChatMessageSentEvent(ChatMessageSentEvent event) {
+
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleSystemMessageSentEvent(SystemMessageSentEvent event) {
+
+    }
+}

--- a/server/src/main/java/ppalatjyo/server/message/MessageEventHandler.java
+++ b/server/src/main/java/ppalatjyo/server/message/MessageEventHandler.java
@@ -6,6 +6,9 @@ import org.springframework.transaction.event.TransactionalEventListener;
 import ppalatjyo.server.message.event.ChatMessageSentEvent;
 import ppalatjyo.server.message.event.SystemMessageSentEvent;
 
+/**
+ * <p> {@link MessageService}가 발행한 이벤트를 처리합니다. {@link MessageService} 각 메서드의 트랜잭션 성공 여부에 따라 처리를 분기합니다. 브로커를 통한 실제 메시지 발행을 담당합니다.
+ */
 @Component
 public class MessageEventHandler {
 

--- a/server/src/main/java/ppalatjyo/server/message/MessageRepository.java
+++ b/server/src/main/java/ppalatjyo/server/message/MessageRepository.java
@@ -1,6 +1,7 @@
 package ppalatjyo.server.message;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import ppalatjyo.server.message.domain.Message;
 
 public interface MessageRepository extends JpaRepository<Message, Long> {
 }

--- a/server/src/main/java/ppalatjyo/server/message/MessageSentEvent.java
+++ b/server/src/main/java/ppalatjyo/server/message/MessageSentEvent.java
@@ -1,0 +1,12 @@
+package ppalatjyo.server.message;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class MessageSentEvent {
+    private Long userId;
+    private Long gameId;
+    private Long messageId;
+}

--- a/server/src/main/java/ppalatjyo/server/message/MessageService.java
+++ b/server/src/main/java/ppalatjyo/server/message/MessageService.java
@@ -1,0 +1,18 @@
+package ppalatjyo.server.message;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import ppalatjyo.server.lobby.LobbyRepository;
+import ppalatjyo.server.user.UserRepository;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class MessageService {
+
+    private final MessageRepository messageRepository;
+    private final UserRepository userRepository;
+    private final LobbyRepository lobbyRepository;
+
+}

--- a/server/src/main/java/ppalatjyo/server/message/MessageService.java
+++ b/server/src/main/java/ppalatjyo/server/message/MessageService.java
@@ -1,10 +1,14 @@
 package ppalatjyo.server.message;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import ppalatjyo.server.lobby.LobbyRepository;
+import ppalatjyo.server.lobby.domain.Lobby;
+import ppalatjyo.server.message.domain.Message;
 import ppalatjyo.server.user.UserRepository;
+import ppalatjyo.server.user.domain.User;
 
 @Service
 @RequiredArgsConstructor
@@ -14,5 +18,17 @@ public class MessageService {
     private final MessageRepository messageRepository;
     private final UserRepository userRepository;
     private final LobbyRepository lobbyRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
+    public void sendChatMessage(String content, Long userId, Long lobbyId) {
+        User user = userRepository.findById(userId).orElseThrow();
+        Lobby lobby = lobbyRepository.findById(lobbyId).orElseThrow();
+
+        Message message = Message.chatMessage(content, user, lobby);
+        messageRepository.save(message);
+
+        // MessageSentEventHandler 에서 트랜잭션 여부에 따라 분기 처리
+        MessageSentEvent event = new MessageSentEvent(userId, lobbyId, message.getId());
+        eventPublisher.publishEvent(event);
+    }
 }

--- a/server/src/main/java/ppalatjyo/server/message/MessageService.java
+++ b/server/src/main/java/ppalatjyo/server/message/MessageService.java
@@ -7,6 +7,8 @@ import org.springframework.transaction.annotation.Transactional;
 import ppalatjyo.server.lobby.LobbyRepository;
 import ppalatjyo.server.lobby.domain.Lobby;
 import ppalatjyo.server.message.domain.Message;
+import ppalatjyo.server.message.event.ChatMessageSentEvent;
+import ppalatjyo.server.message.event.SystemMessageSentEvent;
 import ppalatjyo.server.user.UserRepository;
 import ppalatjyo.server.user.domain.User;
 
@@ -28,7 +30,17 @@ public class MessageService {
         messageRepository.save(message);
 
         // MessageSentEventHandler 에서 트랜잭션 여부에 따라 분기 처리
-        MessageSentEvent event = new MessageSentEvent(userId, lobbyId, message.getId());
+        ChatMessageSentEvent event = new ChatMessageSentEvent(userId, lobbyId, message.getId());
+        eventPublisher.publishEvent(event);
+    }
+
+    public void sendSystemMessage(String content, Long lobbyId) {
+        Lobby lobby = lobbyRepository.findById(lobbyId).orElseThrow();
+
+        Message message = Message.systemMessage(content, lobby);
+        messageRepository.save(message);
+
+        SystemMessageSentEvent event = new SystemMessageSentEvent(lobbyId, message.getId());
         eventPublisher.publishEvent(event);
     }
 }

--- a/server/src/main/java/ppalatjyo/server/message/domain/Message.java
+++ b/server/src/main/java/ppalatjyo/server/message/domain/Message.java
@@ -1,4 +1,4 @@
-package ppalatjyo.server.message;
+package ppalatjyo.server.message.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
@@ -19,6 +19,9 @@ public class Message extends BaseEntity {
     @Column(name = "message_id")
     private Long id;
 
+    @Enumerated(EnumType.STRING)
+    private MessageType type;
+
     private String content;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -33,16 +36,25 @@ public class Message extends BaseEntity {
     @JoinColumn(name = "game_id")
     private Game game;
 
-    public static Message create(String content, User user, Lobby lobby) {
-        return create(content, user, lobby, null);
+    public static Message chatMessage(String content, User user, Lobby lobby) {
+        return chatMessage(content, user, lobby, null);
     }
 
-    public static Message create(String content, User user, Lobby lobby, Game game) {
+    public static Message chatMessage(String content, User user, Lobby lobby, Game game) {
         return Message.builder()
                 .content(content)
+                .type(MessageType.CHAT)
                 .user(user)
                 .lobby(lobby)
                 .game(game)
+                .build();
+    }
+
+    public static Message systemMessage(String content, Lobby lobby) {
+        return Message.builder()
+                .content(content)
+                .type(MessageType.SYSTEM)
+                .lobby(lobby)
                 .build();
     }
 }

--- a/server/src/main/java/ppalatjyo/server/message/domain/MessageType.java
+++ b/server/src/main/java/ppalatjyo/server/message/domain/MessageType.java
@@ -1,0 +1,5 @@
+package ppalatjyo.server.message.domain;
+
+public enum MessageType {
+    CHAT, SYSTEM
+}

--- a/server/src/main/java/ppalatjyo/server/message/event/ChatMessageSentEvent.java
+++ b/server/src/main/java/ppalatjyo/server/message/event/ChatMessageSentEvent.java
@@ -1,12 +1,12 @@
-package ppalatjyo.server.message;
+package ppalatjyo.server.message.event;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
 @Data
 @AllArgsConstructor
-public class MessageSentEvent {
+public class ChatMessageSentEvent {
     private Long userId;
-    private Long gameId;
+    private Long lobbyId;
     private Long messageId;
 }

--- a/server/src/main/java/ppalatjyo/server/message/event/SystemMessageSentEvent.java
+++ b/server/src/main/java/ppalatjyo/server/message/event/SystemMessageSentEvent.java
@@ -1,0 +1,11 @@
+package ppalatjyo.server.message.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class SystemMessageSentEvent {
+    private Long lobbyId;
+    private Long messageId;
+}

--- a/server/src/test/java/ppalatjyo/server/game/GameServiceTest.java
+++ b/server/src/test/java/ppalatjyo/server/game/GameServiceTest.java
@@ -13,7 +13,7 @@ import ppalatjyo.server.gameevent.GameEventService;
 import ppalatjyo.server.lobby.LobbyRepository;
 import ppalatjyo.server.lobby.domain.Lobby;
 import ppalatjyo.server.lobby.domain.LobbyOptions;
-import ppalatjyo.server.message.Message;
+import ppalatjyo.server.message.domain.Message;
 import ppalatjyo.server.message.MessageRepository;
 import ppalatjyo.server.quiz.domain.Answer;
 import ppalatjyo.server.quiz.domain.Question;
@@ -167,7 +167,7 @@ class GameServiceTest {
         UserGame userGame = UserGame.join(user, game);
 
         Long messageId = 1L;
-        Message message = Message.create(answer, user, lobby, game);
+        Message message = Message.chatMessage(answer, user, lobby, game);
 
         SubmitAnswerRequestDto requestDto = new SubmitAnswerRequestDto();
         requestDto.setGameId(gameId);
@@ -206,7 +206,7 @@ class GameServiceTest {
         UserGame userGame = UserGame.join(user, game);
 
         Long messageId = 1L;
-        Message message = Message.create(wrongAnswer, user, lobby, game); // 오답 작성
+        Message message = Message.chatMessage(wrongAnswer, user, lobby, game); // 오답 작성
 
         SubmitAnswerRequestDto requestDto = new SubmitAnswerRequestDto();
         requestDto.setGameId(gameId);

--- a/server/src/test/java/ppalatjyo/server/gameevent/GameEventServiceTest.java
+++ b/server/src/test/java/ppalatjyo/server/gameevent/GameEventServiceTest.java
@@ -13,7 +13,7 @@ import ppalatjyo.server.gameevent.domain.GameEvent;
 import ppalatjyo.server.gameevent.domain.GameEventType;
 import ppalatjyo.server.lobby.domain.Lobby;
 import ppalatjyo.server.lobby.domain.LobbyOptions;
-import ppalatjyo.server.message.Message;
+import ppalatjyo.server.message.domain.Message;
 import ppalatjyo.server.message.MessageRepository;
 import ppalatjyo.server.quiz.domain.Question;
 import ppalatjyo.server.quiz.domain.Quiz;
@@ -133,7 +133,7 @@ class GameEventServiceTest {
         UserGame userGame = game.getUserGames().getFirst();
 
         Long messageId = 1L;
-        Message message = Message.create("message", user, lobby);
+        Message message = Message.chatMessage("message", user, lobby);
         when(gameRepository.findById(gameId)).thenReturn(Optional.of(game));
         when(userGameRepository.findById(userGameId)).thenReturn(Optional.of(userGame));
         when(messageRepository.findById(messageId)).thenReturn(Optional.of(message));
@@ -168,7 +168,7 @@ class GameEventServiceTest {
         UserGame userGame = game.getUserGames().getFirst();
 
         Long messageId = 1L;
-        Message message = Message.create("message", user, lobby);
+        Message message = Message.chatMessage("message", user, lobby);
         when(gameRepository.findById(gameId)).thenReturn(Optional.of(game));
         when(userGameRepository.findById(userGameId)).thenReturn(Optional.of(userGame));
         when(messageRepository.findById(messageId)).thenReturn(Optional.of(message));

--- a/server/src/test/java/ppalatjyo/server/gameevent/GameEventTest.java
+++ b/server/src/test/java/ppalatjyo/server/gameevent/GameEventTest.java
@@ -7,7 +7,7 @@ import ppalatjyo.server.gameevent.domain.GameEvent;
 import ppalatjyo.server.gameevent.domain.GameEventType;
 import ppalatjyo.server.lobby.domain.Lobby;
 import ppalatjyo.server.lobby.domain.LobbyOptions;
-import ppalatjyo.server.message.Message;
+import ppalatjyo.server.message.domain.Message;
 import ppalatjyo.server.quiz.domain.Answer;
 import ppalatjyo.server.quiz.domain.Question;
 import ppalatjyo.server.quiz.domain.Quiz;
@@ -59,7 +59,7 @@ class GameEventTest {
         Lobby lobby = Lobby.createLobby("lobby", user, getQuiz(), LobbyOptions.defaultOptions());
         Game game = Game.start(lobby);
         UserGame userGame = UserGame.join(user, game);
-        Message message = Message.create(wrongAnswer, user, lobby, game);
+        Message message = Message.chatMessage(wrongAnswer, user, lobby, game);
 
         // when
         GameEvent gameEvent = GameEvent.wrongAnswer(game, userGame, message);
@@ -80,7 +80,7 @@ class GameEventTest {
         Lobby lobby = Lobby.createLobby("lobby", user, getQuiz(), LobbyOptions.defaultOptions());
         Game game = Game.start(lobby);
         UserGame userGame = UserGame.join(user, game);
-        Message message = Message.create(rightAnswer, user, lobby, game);
+        Message message = Message.chatMessage(rightAnswer, user, lobby, game);
 
         // when
         GameEvent gameEvent = GameEvent.rightAnswer(game, userGame, message);

--- a/server/src/test/java/ppalatjyo/server/message/MessageServiceTest.java
+++ b/server/src/test/java/ppalatjyo/server/message/MessageServiceTest.java
@@ -1,13 +1,26 @@
 package ppalatjyo.server.message;
 
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import ppalatjyo.server.lobby.LobbyRepository;
+import ppalatjyo.server.lobby.domain.Lobby;
+import ppalatjyo.server.message.domain.Message;
+import ppalatjyo.server.message.domain.MessageType;
 import ppalatjyo.server.user.UserRepository;
+import ppalatjyo.server.user.domain.User;
 
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class MessageServiceTest {
@@ -18,7 +31,36 @@ class MessageServiceTest {
     private UserRepository userRepository;
     @Mock
     private LobbyRepository lobbyRepository;
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
 
     @InjectMocks
     private MessageService messageService;
+
+    @Test
+    @DisplayName("채팅 메시지 생성/전송")
+    void createChatMessage() {
+        // given
+        String content = "content";
+
+        User user = User.createGuest("user");
+        Lobby lobby = Lobby.createLobby("lobby", user, null, null);
+
+        when(userRepository.findById(anyLong())).thenReturn(Optional.of(user));
+        when(lobbyRepository.findById(anyLong())).thenReturn(Optional.of(lobby));
+
+        // when
+        messageService.sendChatMessage(content, 1L, 1L);
+
+        // then
+        ArgumentCaptor<Message> captor = ArgumentCaptor.forClass(Message.class);
+        verify(messageRepository, times(1)).save(captor.capture());
+        verify(eventPublisher, times(1)).publishEvent(any(MessageSentEvent.class));
+
+        Message message = captor.getValue();
+        assertThat(message.getContent()).isEqualTo(content);
+        assertThat(message.getUser()).isEqualTo(user);
+        assertThat(message.getLobby()).isEqualTo(lobby);
+        assertThat(message.getType()).isEqualTo(MessageType.CHAT);
+    }
 }

--- a/server/src/test/java/ppalatjyo/server/message/MessageServiceTest.java
+++ b/server/src/test/java/ppalatjyo/server/message/MessageServiceTest.java
@@ -1,0 +1,24 @@
+package ppalatjyo.server.message;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import ppalatjyo.server.lobby.LobbyRepository;
+import ppalatjyo.server.user.UserRepository;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+class MessageServiceTest {
+
+    @Mock
+    private MessageRepository messageRepository;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private LobbyRepository lobbyRepository;
+
+    @InjectMocks
+    private MessageService messageService;
+}

--- a/server/src/test/java/ppalatjyo/server/message/MessageTest.java
+++ b/server/src/test/java/ppalatjyo/server/message/MessageTest.java
@@ -5,6 +5,8 @@ import org.junit.jupiter.api.Test;
 import ppalatjyo.server.game.domain.Game;
 import ppalatjyo.server.lobby.domain.Lobby;
 import ppalatjyo.server.lobby.domain.LobbyOptions;
+import ppalatjyo.server.message.domain.Message;
+import ppalatjyo.server.message.domain.MessageType;
 import ppalatjyo.server.quiz.domain.Answer;
 import ppalatjyo.server.quiz.domain.Question;
 import ppalatjyo.server.quiz.domain.Quiz;
@@ -15,15 +17,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 class MessageTest {
 
     @Test
-    @DisplayName("메시지 생성: 유저 -> 로비")
-    void create() {
+    @DisplayName("채팅 메시지: 유저 -> 로비")
+    void chatMessage() {
         // given
         String content = "content";
         User user = User.createGuest("user");
         Lobby lobby = Lobby.createLobby("lobby", user, null, LobbyOptions.defaultOptions());
 
         // when
-        Message message = Message.create(content, user, lobby);
+        Message message = Message.chatMessage(content, user, lobby);
 
         // then
         assertThat(message.getContent()).isEqualTo(content);
@@ -32,8 +34,8 @@ class MessageTest {
     }
 
     @Test
-    @DisplayName("메시지 생성: 유저 -> 게임")
-    void createToGame() {
+    @DisplayName("채팅 메시지: 유저 -> 게임")
+    void chatMessageToGame() {
         // given
         String content = "content";
         User user = User.createGuest("user");
@@ -41,13 +43,32 @@ class MessageTest {
         Game game = Game.start(lobby);
 
         // when
-        Message message = Message.create(content, user, lobby, game);
+        Message message = Message.chatMessage(content, user, lobby, game);
 
         // then
         assertThat(message.getContent()).isEqualTo(content);
         assertThat(message.getUser()).isEqualTo(user);
         assertThat(message.getLobby()).isEqualTo(lobby);
         assertThat(message.getGame()).isEqualTo(game);
+    }
+
+    @Test
+    @DisplayName("시스템 메시지")
+    void chatMessageSystemMessage() {
+        // given
+        String content = "content";
+        User user = User.createGuest("user");
+        Lobby lobby = Lobby.createLobby("lobby", user, getQuiz(), LobbyOptions.defaultOptions());
+
+        // when
+        Message message = Message.systemMessage(content, lobby);
+
+        // then
+        assertThat(message.getType()).isEqualTo(MessageType.SYSTEM);
+        assertThat(message.getContent()).isEqualTo(content);
+        assertThat(message.getUser()).isNull();
+        assertThat(message.getLobby()).isEqualTo(lobby);
+        assertThat(message.getGame()).isNull();
     }
 
     private Quiz getQuiz() {


### PR DESCRIPTION
## 관련 이슈

- #38 

## 변경 사항

- [MessageService](server/src/main/java/ppalatjyo/server/game/GameService.java)를 구현하였습니다.
- `MessageService` 각 메서드의 트랜잭션 여부에 따라 실제 메시지 발행을 분기 처리하기 위해 `MessageService`는 이벤트를 발행하도록 구현하였습니다.
- `MessageEventHandler`가 각 메시지 전송 이벤트를 `@TransactionalEventHandler` 기능을 통해 커밋 시에만 브로커를 통해 메시지를 발송하도록 처리합니다.

## 고려 사항 및 주의 사항 (선택)

- `GameService`도 마찬가지로 이벤트를 발행하고 `GameEventService`를 `GameEventHandler`로 이름을 바꾸어 이를 처리하도록 리펙토링 합니다.
- 메시지 브로커를 사용하는 클래스는 EventHandler 메서드로 한정합니다. -> 혹은 사용하기 편하게 `MessageBrokerService` 등의 추상화 계층을 추가 도입합니다.
- TODO: 웹소켓 도입 이후 핸들러들에 대한 추가 구현이 필요합니다.

## 추가 정보 (선택)
