### PR TITLE
[FEATURE #26]: Spring 기본 오류 응답 형태 통일

### DIFF
--- a/server/src/docs/asciidoc/index.adoc
+++ b/server/src/docs/asciidoc/index.adoc
@@ -11,22 +11,22 @@ include::{snippets}/hello/http-request.adoc[]
 .response
 include::{snippets}/hello/http-response.adoc[]
 
-=== Validation Example
+== Global Error Response
 
-Request
+=== Internal Server Error (500)
 
-.request
-include::{snippets}/validation-success/http-request.adoc[]
-.request body
-include::{snippets}/validation-success/request-body.adoc[]
-.request fields
-include::{snippets}/validation-success/request-fields.adoc[]
+include::{snippets}/internal-server-error/response-body.adoc[]
 
-Response
+include::{snippets}/internal-server-error/response-fields.adoc[]
 
-.Success
-include::{snippets}/validation-success/response-body.adoc[]
-.Validation Fail
+=== Not Found (404)
+
+include::{snippets}/no-such-element-exception/response-body.adoc[]
+
+include::{snippets}/no-such-element-exception/response-fields.adoc[]
+
+=== Validation Fail (400)
+
 include::{snippets}/validation-fail/response-body.adoc[]
 
 include::{snippets}/validation-fail/response-fields.adoc[]

--- a/server/src/main/java/ppalatjyo/server/game/GameService.java
+++ b/server/src/main/java/ppalatjyo/server/game/GameService.java
@@ -5,12 +5,16 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import ppalatjyo.server.game.domain.Game;
 import ppalatjyo.server.game.dto.SubmitAnswerRequestDto;
+import ppalatjyo.server.game.exception.GameNotFoundException;
+import ppalatjyo.server.lobby.exception.LobbyNotFoundException;
 import ppalatjyo.server.gameevent.GameEventService;
 import ppalatjyo.server.lobby.LobbyRepository;
 import ppalatjyo.server.lobby.domain.Lobby;
+import ppalatjyo.server.message.MessageNotFoundException;
 import ppalatjyo.server.message.domain.Message;
 import ppalatjyo.server.message.MessageRepository;
 import ppalatjyo.server.usergame.UserGame;
+import ppalatjyo.server.usergame.UserGameNotFoundException;
 import ppalatjyo.server.usergame.UserGameRepository;
 
 @Service
@@ -25,7 +29,7 @@ public class GameService {
     private final GameEventService gameEventService;
 
     public void start(Long lobbyId) {
-        Lobby lobby = lobbyRepository.findById(lobbyId).orElseThrow();
+        Lobby lobby = lobbyRepository.findById(lobbyId).orElseThrow(LobbyNotFoundException::new);
 
         Game game = Game.start(lobby);
 
@@ -34,19 +38,19 @@ public class GameService {
     }
 
     public void nextQuestion(Long gameId) {
-        Game game = gameRepository.findById(gameId).orElseThrow();
+        Game game = gameRepository.findById(gameId).orElseThrow(GameNotFoundException::new);
         game.nextQuestion();
     }
 
     public void end(Long gameId) {
-        Game game = gameRepository.findById(gameId).orElseThrow();
+        Game game = gameRepository.findById(gameId).orElseThrow(GameNotFoundException::new);
         game.end();
     }
 
     public void submitAnswer(SubmitAnswerRequestDto requestDto) {
-        Game game = gameRepository.findById(requestDto.getGameId()).orElseThrow();
-        UserGame userGame = userGameRepository.findById(requestDto.getUserGameId()).orElseThrow();
-        Message message = messageRepository.findById(requestDto.getMessageId()).orElseThrow();
+        Game game = gameRepository.findById(requestDto.getGameId()).orElseThrow(GameNotFoundException::new);
+        UserGame userGame = userGameRepository.findById(requestDto.getUserGameId()).orElseThrow(UserGameNotFoundException::new);
+        Message message = messageRepository.findById(requestDto.getMessageId()).orElseThrow(MessageNotFoundException::new);
 
         boolean isCorrect = game.getCurrentQuestion().isCorrect(message.getContent());
         if (isCorrect) {

--- a/server/src/main/java/ppalatjyo/server/game/exception/GameNotFoundException.java
+++ b/server/src/main/java/ppalatjyo/server/game/exception/GameNotFoundException.java
@@ -1,0 +1,9 @@
+package ppalatjyo.server.game.exception;
+
+import java.util.NoSuchElementException;
+
+public class GameNotFoundException extends NoSuchElementException {
+    public GameNotFoundException() {
+        super("Game not found");
+    }
+}

--- a/server/src/main/java/ppalatjyo/server/gameevent/GameEventService.java
+++ b/server/src/main/java/ppalatjyo/server/gameevent/GameEventService.java
@@ -5,10 +5,13 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import ppalatjyo.server.game.GameRepository;
 import ppalatjyo.server.game.domain.Game;
+import ppalatjyo.server.game.exception.GameNotFoundException;
 import ppalatjyo.server.gameevent.domain.GameEvent;
+import ppalatjyo.server.message.MessageNotFoundException;
 import ppalatjyo.server.message.domain.Message;
 import ppalatjyo.server.message.MessageRepository;
 import ppalatjyo.server.usergame.UserGame;
+import ppalatjyo.server.usergame.UserGameNotFoundException;
 import ppalatjyo.server.usergame.UserGameRepository;
 
 @Service
@@ -22,36 +25,36 @@ public class GameEventService {
     private final MessageRepository messageRepository;
 
     public void started(Long gameId) {
-        Game game = gameRepository.findById(gameId).orElseThrow();
+        Game game = gameRepository.findById(gameId).orElseThrow(GameNotFoundException::new);
         GameEvent gameEvent = GameEvent.started(game);
         gameEventRepository.save(gameEvent);
     }
 
     public void ended(Long gameId) {
-        Game game = gameRepository.findById(gameId).orElseThrow();
+        Game game = gameRepository.findById(gameId).orElseThrow(GameNotFoundException::new);
         GameEvent gameEvent = GameEvent.ended(game);
         gameEventRepository.save(gameEvent);
     }
 
     public void timeOut(Long gameId) {
-        Game game = gameRepository.findById(gameId).orElseThrow();
+        Game game = gameRepository.findById(gameId).orElseThrow(GameNotFoundException::new);
         GameEvent gameEvent = GameEvent.timeOut(game);
         gameEventRepository.save(gameEvent);
     }
 
     public void rightAnswer(Long gameId, Long userGameId, Long messageId) {
-        Game game = gameRepository.findById(gameId).orElseThrow();
-        UserGame userGame = userGameRepository.findById(userGameId).orElseThrow();
-        Message message = messageRepository.findById(messageId).orElseThrow();
+        Game game = gameRepository.findById(gameId).orElseThrow(GameNotFoundException::new);
+        UserGame userGame = userGameRepository.findById(userGameId).orElseThrow(UserGameNotFoundException::new);
+        Message message = messageRepository.findById(messageId).orElseThrow(MessageNotFoundException::new);
 
         GameEvent gameEvent = GameEvent.rightAnswer(game, userGame, message);
         gameEventRepository.save(gameEvent);
     }
 
     public void wrongAnswer(Long gameId, Long userGameId, Long messageId) {
-        Game game = gameRepository.findById(gameId).orElseThrow();
-        UserGame userGame = userGameRepository.findById(userGameId).orElseThrow();
-        Message message = messageRepository.findById(messageId).orElseThrow();
+        Game game = gameRepository.findById(gameId).orElseThrow(GameNotFoundException::new);
+        UserGame userGame = userGameRepository.findById(userGameId).orElseThrow(UserGameNotFoundException::new);
+        Message message = messageRepository.findById(messageId).orElseThrow(MessageNotFoundException::new);
 
         GameEvent gameEvent = GameEvent.wrongAnswer(game, userGame, message);
         gameEventRepository.save(gameEvent);

--- a/server/src/main/java/ppalatjyo/server/global/dto/ResponseDtoTestController.java
+++ b/server/src/main/java/ppalatjyo/server/global/dto/ResponseDtoTestController.java
@@ -4,11 +4,23 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.NoSuchElementException;
+
 @RestController
 public class ResponseDtoTestController {
 
     @GetMapping("/test/response/ok")
     public ResponseEntity<ResponseDto<Void>> testOk() {
         return ResponseDto.ok();
+    }
+
+    @GetMapping("/test/notfound")
+    public void testNotFound() {
+        throw new NoSuchElementException("User Not Found");
+    }
+
+    @GetMapping("/test/error")
+    public void testError() {
+        throw new RuntimeException("Something went wrong");
     }
 }

--- a/server/src/main/java/ppalatjyo/server/global/dto/handler/GlobalExceptionHandler.java
+++ b/server/src/main/java/ppalatjyo/server/global/dto/handler/GlobalExceptionHandler.java
@@ -1,0 +1,46 @@
+package ppalatjyo.server.global.dto.handler;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import ppalatjyo.server.global.dto.ResponseDto;
+import ppalatjyo.server.global.dto.error.ResponseErrorDto;
+
+import java.util.NoSuchElementException;
+
+@RestControllerAdvice
+@Slf4j
+public class GlobalExceptionHandler {
+
+    /**
+     * NoSuchElementException 발생 시 404 NOT_FOUND로 응답하는 핸들러. NoSuchElementException을 상속받는 각 클래스에 에러 메시지를 포함해두어 그것을 사용합니다.
+     *
+     * <p> 예: ex.getMessage() -> "User Not Found"
+     *
+     * @param ex      발생된 예외
+     * @param request 현재 요청 정보
+     * @return 404 상태를 갖는 표준 ResponseDto
+     */
+    @ExceptionHandler(NoSuchElementException.class)
+    public ResponseEntity<ResponseDto<Void>> handleNoSuchElementException(NoSuchElementException ex, HttpServletRequest request) {
+        ResponseErrorDto errorDto = ResponseErrorDto.commonError(ex.getMessage(), request.getRequestURI());
+        return ResponseDto.error(HttpStatus.NOT_FOUND, errorDto);
+    }
+
+    /**
+     * 기타 예외 발생 시 500 Internal Server Error로 응답하는 핸들러. 정확히 어떤 에러가 발생했는지 모르기 때문에 예외 메시지를 드러내지 않습니다. 대신 로그로 남깁니다.
+     *
+     * @param ex      발생된 예외
+     * @param request 현재 요청 정보
+     * @return 500 상태를 갖는 표준 ResponseDto
+     */
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ResponseDto<Void>> handleException(Exception ex, HttpServletRequest request) {
+        log.error(ex.getMessage(), ex);
+        ResponseErrorDto errorDto = ResponseErrorDto.commonError("Server Error", request.getRequestURI());
+        return ResponseDto.error(HttpStatus.INTERNAL_SERVER_ERROR, errorDto);
+    }
+}

--- a/server/src/main/java/ppalatjyo/server/lobby/LobbyService.java
+++ b/server/src/main/java/ppalatjyo/server/lobby/LobbyService.java
@@ -5,10 +5,13 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import ppalatjyo.server.lobby.domain.Lobby;
 import ppalatjyo.server.lobby.domain.LobbyOptions;
+import ppalatjyo.server.lobby.exception.LobbyNotFoundException;
 import ppalatjyo.server.quiz.domain.Quiz;
+import ppalatjyo.server.quiz.exception.QuizNotFoundException;
 import ppalatjyo.server.quiz.repository.QuizRepository;
 import ppalatjyo.server.user.UserRepository;
 import ppalatjyo.server.user.domain.User;
+import ppalatjyo.server.user.exception.UserNotFoundException;
 
 @Service
 @RequiredArgsConstructor
@@ -20,33 +23,33 @@ public class LobbyService {
     private final QuizRepository quizRepository;
 
     public void createLobby(String name, long hostId, long quizId, LobbyOptions options) {
-        User host = userRepository.findById(hostId).orElseThrow();
-        Quiz quiz = quizRepository.findById(quizId).orElseThrow();
+        User host = userRepository.findById(hostId).orElseThrow(UserNotFoundException::new);
+        Quiz quiz = quizRepository.findById(quizId).orElseThrow(QuizNotFoundException::new);
 
         Lobby lobby = Lobby.createLobby(name, host, quiz, options);
         lobbyRepository.save(lobby);
     }
 
     public void changeOptions(long lobbyId, LobbyOptions options) {
-        Lobby lobby = lobbyRepository.findById(lobbyId).orElseThrow();
+        Lobby lobby = lobbyRepository.findById(lobbyId).orElseThrow(LobbyNotFoundException::new);
         lobby.changeOptions(options);
     }
 
     public void delete(long lobbyId) {
-        Lobby lobby = lobbyRepository.findById(lobbyId).orElseThrow();
+        Lobby lobby = lobbyRepository.findById(lobbyId).orElseThrow(LobbyNotFoundException::new);
         lobby.delete();
     }
 
     public void changeHost(long lobbyId, long newHostId) {
-        Lobby lobby = lobbyRepository.findById(lobbyId).orElseThrow();
-        User newHost = userRepository.findById(newHostId).orElseThrow();
+        Lobby lobby = lobbyRepository.findById(lobbyId).orElseThrow(LobbyNotFoundException::new);
+        User newHost = userRepository.findById(newHostId).orElseThrow(UserNotFoundException::new);
 
         lobby.changeHost(newHost);
     }
 
     public void changeQuiz(long lobbyId, long quizId) {
-        Lobby lobby = lobbyRepository.findById(lobbyId).orElseThrow();
-        Quiz quiz = quizRepository.findById(quizId).orElseThrow();
+        Lobby lobby = lobbyRepository.findById(lobbyId).orElseThrow(LobbyNotFoundException::new);
+        Quiz quiz = quizRepository.findById(quizId).orElseThrow(QuizNotFoundException::new);
 
         lobby.changeQuiz(quiz);
     }

--- a/server/src/main/java/ppalatjyo/server/lobby/domain/Lobby.java
+++ b/server/src/main/java/ppalatjyo/server/lobby/domain/Lobby.java
@@ -3,7 +3,7 @@ package ppalatjyo.server.lobby.domain;
 import jakarta.persistence.*;
 import lombok.*;
 import ppalatjyo.server.global.audit.BaseEntity;
-import ppalatjyo.server.lobby.LobbyAlreadyDeletedException;
+import ppalatjyo.server.lobby.exception.LobbyAlreadyDeletedException;
 import ppalatjyo.server.quiz.domain.Quiz;
 import ppalatjyo.server.user.domain.User;
 import ppalatjyo.server.userlobby.UserLobby;

--- a/server/src/main/java/ppalatjyo/server/lobby/exception/LobbyAlreadyDeletedException.java
+++ b/server/src/main/java/ppalatjyo/server/lobby/exception/LobbyAlreadyDeletedException.java
@@ -1,4 +1,4 @@
-package ppalatjyo.server.lobby;
+package ppalatjyo.server.lobby.exception;
 
 public class LobbyAlreadyDeletedException extends RuntimeException {
     public LobbyAlreadyDeletedException() {

--- a/server/src/main/java/ppalatjyo/server/lobby/exception/LobbyNotFoundException.java
+++ b/server/src/main/java/ppalatjyo/server/lobby/exception/LobbyNotFoundException.java
@@ -1,0 +1,9 @@
+package ppalatjyo.server.lobby.exception;
+
+import java.util.NoSuchElementException;
+
+public class LobbyNotFoundException extends NoSuchElementException {
+    public LobbyNotFoundException() {
+        super("Lobby not found");
+    }
+}

--- a/server/src/main/java/ppalatjyo/server/message/MessageNotFoundException.java
+++ b/server/src/main/java/ppalatjyo/server/message/MessageNotFoundException.java
@@ -1,0 +1,9 @@
+package ppalatjyo.server.message;
+
+import java.util.NoSuchElementException;
+
+public class MessageNotFoundException extends NoSuchElementException {
+    public MessageNotFoundException() {
+        super("Message not found");
+    }
+}

--- a/server/src/main/java/ppalatjyo/server/message/MessageService.java
+++ b/server/src/main/java/ppalatjyo/server/message/MessageService.java
@@ -6,11 +6,13 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import ppalatjyo.server.lobby.LobbyRepository;
 import ppalatjyo.server.lobby.domain.Lobby;
+import ppalatjyo.server.lobby.exception.LobbyNotFoundException;
 import ppalatjyo.server.message.domain.Message;
 import ppalatjyo.server.message.event.ChatMessageSentEvent;
 import ppalatjyo.server.message.event.SystemMessageSentEvent;
 import ppalatjyo.server.user.UserRepository;
 import ppalatjyo.server.user.domain.User;
+import ppalatjyo.server.user.exception.UserNotFoundException;
 
 @Service
 @RequiredArgsConstructor
@@ -23,8 +25,8 @@ public class MessageService {
     private final ApplicationEventPublisher eventPublisher;
 
     public void sendChatMessage(String content, Long userId, Long lobbyId) {
-        User user = userRepository.findById(userId).orElseThrow();
-        Lobby lobby = lobbyRepository.findById(lobbyId).orElseThrow();
+        User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
+        Lobby lobby = lobbyRepository.findById(lobbyId).orElseThrow(LobbyNotFoundException::new);
 
         Message message = Message.chatMessage(content, user, lobby);
         messageRepository.save(message);
@@ -35,7 +37,7 @@ public class MessageService {
     }
 
     public void sendSystemMessage(String content, Long lobbyId) {
-        Lobby lobby = lobbyRepository.findById(lobbyId).orElseThrow();
+        Lobby lobby = lobbyRepository.findById(lobbyId).orElseThrow(LobbyNotFoundException::new);
 
         Message message = Message.systemMessage(content, lobby);
         messageRepository.save(message);

--- a/server/src/main/java/ppalatjyo/server/quiz/AnswerService.java
+++ b/server/src/main/java/ppalatjyo/server/quiz/AnswerService.java
@@ -7,6 +7,8 @@ import ppalatjyo.server.quiz.domain.Answer;
 import ppalatjyo.server.quiz.domain.Question;
 import ppalatjyo.server.quiz.dto.AnswerCreateRequestDto;
 import ppalatjyo.server.quiz.dto.AnswerUpdateRequestDto;
+import ppalatjyo.server.quiz.exception.AnswerNotFoundException;
+import ppalatjyo.server.quiz.exception.QuestionNotFoundException;
 import ppalatjyo.server.quiz.repository.AnswerRepository;
 import ppalatjyo.server.quiz.repository.QuestionRepository;
 
@@ -19,18 +21,18 @@ public class AnswerService {
     private final QuestionRepository questionRepository;
 
     public void create(AnswerCreateRequestDto requestDto) {
-        Question question = questionRepository.findById(requestDto.getQuestionId()).orElseThrow();
+        Question question = questionRepository.findById(requestDto.getQuestionId()).orElseThrow(QuestionNotFoundException::new);
         Answer answer = Answer.createAnswer(question, requestDto.getContent());
         answerRepository.save(answer);
     }
 
     public void update(AnswerUpdateRequestDto requestDto) {
-        Answer answer = answerRepository.findById(requestDto.getAnswerId()).orElseThrow();
+        Answer answer = answerRepository.findById(requestDto.getAnswerId()).orElseThrow(AnswerNotFoundException::new);
         answer.changeContent(requestDto.getContent());
     }
 
     public void delete(Long answerId) {
-        Answer answer = answerRepository.findById(answerId).orElseThrow();
+        Answer answer = answerRepository.findById(answerId).orElseThrow(AnswerNotFoundException::new);
         answer.delete();
     }
 }

--- a/server/src/main/java/ppalatjyo/server/quiz/QuestionService.java
+++ b/server/src/main/java/ppalatjyo/server/quiz/QuestionService.java
@@ -7,6 +7,8 @@ import ppalatjyo.server.quiz.domain.Question;
 import ppalatjyo.server.quiz.domain.Quiz;
 import ppalatjyo.server.quiz.dto.QuestionCreateRequestDto;
 import ppalatjyo.server.quiz.dto.QuestionUpdateRequestDto;
+import ppalatjyo.server.quiz.exception.QuestionNotFoundException;
+import ppalatjyo.server.quiz.exception.QuizNotFoundException;
 import ppalatjyo.server.quiz.repository.QuestionRepository;
 import ppalatjyo.server.quiz.repository.QuizRepository;
 
@@ -19,13 +21,13 @@ public class QuestionService {
     private final QuizRepository quizRepository;
 
     public void create(QuestionCreateRequestDto requestDto) {
-        Quiz quiz = quizRepository.findById(requestDto.getQuizId()).orElseThrow();
+        Quiz quiz = quizRepository.findById(requestDto.getQuizId()).orElseThrow(QuizNotFoundException::new);
         Question question = Question.create(quiz, requestDto.getContent());
         questionRepository.save(question);
     }
 
     public void updateQuestion(QuestionUpdateRequestDto requestDto) {
-        Question question = questionRepository.findById(requestDto.getQuestionId()).orElseThrow();
+        Question question = questionRepository.findById(requestDto.getQuestionId()).orElseThrow(QuestionNotFoundException::new);
 
         String content = requestDto.getContent();
         if (!content.isBlank()) {
@@ -34,7 +36,7 @@ public class QuestionService {
     }
 
     public void delete(Long questionId) {
-        Question question = questionRepository.findById(questionId).orElseThrow();
+        Question question = questionRepository.findById(questionId).orElseThrow(QuestionNotFoundException::new);
         question.delete();
     }
 }

--- a/server/src/main/java/ppalatjyo/server/quiz/QuizService.java
+++ b/server/src/main/java/ppalatjyo/server/quiz/QuizService.java
@@ -4,9 +4,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import ppalatjyo.server.quiz.domain.Quiz;
+import ppalatjyo.server.quiz.exception.QuizNotFoundException;
 import ppalatjyo.server.quiz.repository.QuizRepository;
 import ppalatjyo.server.user.UserRepository;
 import ppalatjyo.server.user.domain.User;
+import ppalatjyo.server.user.exception.UserNotFoundException;
 
 @Service
 @Transactional
@@ -17,18 +19,18 @@ public class QuizService {
     private final UserRepository userRepository;
 
     public void create(String title, Long userId) {
-        User user = userRepository.findById(userId).orElseThrow();
+        User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
         Quiz quiz = Quiz.createQuiz(title, user);
         quizRepository.save(quiz);
     }
 
     public void changeTitle(Long quizId, String title) {
-        Quiz quiz = quizRepository.findById(quizId).orElseThrow();
+        Quiz quiz = quizRepository.findById(quizId).orElseThrow(QuizNotFoundException::new);
         quiz.changeTitle(title);
     }
 
     public void delete(Long quizId) {
-        Quiz quiz = quizRepository.findById(quizId).orElseThrow();
+        Quiz quiz = quizRepository.findById(quizId).orElseThrow(QuizNotFoundException::new);
         quiz.delete();
     }
 }

--- a/server/src/main/java/ppalatjyo/server/quiz/exception/AnswerNotFoundException.java
+++ b/server/src/main/java/ppalatjyo/server/quiz/exception/AnswerNotFoundException.java
@@ -1,0 +1,9 @@
+package ppalatjyo.server.quiz.exception;
+
+import java.util.NoSuchElementException;
+
+public class AnswerNotFoundException extends NoSuchElementException {
+    public AnswerNotFoundException() {
+        super("Answer not found");
+    }
+}

--- a/server/src/main/java/ppalatjyo/server/quiz/exception/QuestionNotFoundException.java
+++ b/server/src/main/java/ppalatjyo/server/quiz/exception/QuestionNotFoundException.java
@@ -1,0 +1,9 @@
+package ppalatjyo.server.quiz.exception;
+
+import java.util.NoSuchElementException;
+
+public class QuestionNotFoundException extends NoSuchElementException {
+    public QuestionNotFoundException() {
+        super("Question not found");
+    }
+}

--- a/server/src/main/java/ppalatjyo/server/quiz/exception/QuizNotFoundException.java
+++ b/server/src/main/java/ppalatjyo/server/quiz/exception/QuizNotFoundException.java
@@ -1,0 +1,9 @@
+package ppalatjyo.server.quiz.exception;
+
+import java.util.NoSuchElementException;
+
+public class QuizNotFoundException extends NoSuchElementException {
+    public QuizNotFoundException() {
+        super("Quiz not found");
+    }
+}

--- a/server/src/main/java/ppalatjyo/server/user/UserService.java
+++ b/server/src/main/java/ppalatjyo/server/user/UserService.java
@@ -6,6 +6,7 @@ import org.springframework.transaction.annotation.Transactional;
 import ppalatjyo.server.user.domain.User;
 import ppalatjyo.server.user.dto.JoinAsGuestResponseDto;
 import ppalatjyo.server.user.dto.JoinAsMemberResponseDto;
+import ppalatjyo.server.user.exception.UserNotFoundException;
 
 @Service
 @RequiredArgsConstructor
@@ -29,17 +30,17 @@ public class UserService {
     }
 
     public void promoteGuestToMember(Long userId, String oAuthEmail, String oAuthProvider) {
-        User user = userRepository.findById(userId).orElseThrow();
+        User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
         user.promoteGuestToMember(oAuthEmail, oAuthProvider);
     }
 
     public void changeNickname(Long userId, String newNickname) {
-        User user = userRepository.findById(userId).orElseThrow();
+        User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
         user.changeNickname(newNickname);
     }
 
     public void deleteUser(Long userId) {
-        User user = userRepository.findById(userId).orElseThrow();
+        User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
         user.delete();
     }
 }

--- a/server/src/main/java/ppalatjyo/server/user/exception/UserNotFoundException.java
+++ b/server/src/main/java/ppalatjyo/server/user/exception/UserNotFoundException.java
@@ -1,0 +1,9 @@
+package ppalatjyo.server.user.exception;
+
+import java.util.NoSuchElementException;
+
+public class UserNotFoundException extends NoSuchElementException {
+    public UserNotFoundException() {
+        super("User not found");
+    }
+}

--- a/server/src/main/java/ppalatjyo/server/usergame/UserGameNotFoundException.java
+++ b/server/src/main/java/ppalatjyo/server/usergame/UserGameNotFoundException.java
@@ -1,0 +1,9 @@
+package ppalatjyo.server.usergame;
+
+import java.util.NoSuchElementException;
+
+public class UserGameNotFoundException extends NoSuchElementException {
+    public UserGameNotFoundException() {
+        super("UserGame not found");
+    }
+}

--- a/server/src/main/java/ppalatjyo/server/usergame/UserGameService.java
+++ b/server/src/main/java/ppalatjyo/server/usergame/UserGameService.java
@@ -12,7 +12,7 @@ public class UserGameService {
     private final UserGameRepository userGameRepository;
 
     public void addScore(Long userGameId) {
-        UserGame userGame = userGameRepository.findById(userGameId).orElseThrow();
+        UserGame userGame = userGameRepository.findById(userGameId).orElseThrow(UserGameNotFoundException::new);
         userGame.increaseScore();
     }
 }

--- a/server/src/main/java/ppalatjyo/server/userlobby/UserLobbyNotFoundException.java
+++ b/server/src/main/java/ppalatjyo/server/userlobby/UserLobbyNotFoundException.java
@@ -1,0 +1,9 @@
+package ppalatjyo.server.userlobby;
+
+import java.util.NoSuchElementException;
+
+public class UserLobbyNotFoundException extends NoSuchElementException {
+    public UserLobbyNotFoundException() {
+        super("UserLobby not found");
+    }
+}

--- a/server/src/main/java/ppalatjyo/server/userlobby/UserLobbyService.java
+++ b/server/src/main/java/ppalatjyo/server/userlobby/UserLobbyService.java
@@ -5,8 +5,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import ppalatjyo.server.lobby.LobbyRepository;
 import ppalatjyo.server.lobby.domain.Lobby;
+import ppalatjyo.server.lobby.exception.LobbyNotFoundException;
 import ppalatjyo.server.user.UserRepository;
 import ppalatjyo.server.user.domain.User;
+import ppalatjyo.server.user.exception.UserNotFoundException;
 
 @Service
 @RequiredArgsConstructor
@@ -18,8 +20,8 @@ public class UserLobbyService {
     private final UserLobbyRepository userLobbyRepository;
 
     public void join(Long userId, Long lobbyId) { // TODO: 참가 메시지 전송
-        User user = userRepository.findById(userId).orElseThrow();
-        Lobby lobby = lobbyRepository.findById(lobbyId).orElseThrow();
+        User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
+        Lobby lobby = lobbyRepository.findById(lobbyId).orElseThrow(LobbyNotFoundException::new);
 
         UserLobby userLobby = UserLobby.join(user, lobby);
 
@@ -27,7 +29,7 @@ public class UserLobbyService {
     }
 
     public void leave(Long userId, Long lobbyId) { // TODO: 퇴장 메시지 전송
-        UserLobby userLobby = userLobbyRepository.findByUserIdAndLobbyId(userId, lobbyId).orElseThrow();
+        UserLobby userLobby = userLobbyRepository.findByUserIdAndLobbyId(userId, lobbyId).orElseThrow(UserLobbyNotFoundException::new);
         userLobby.leave();
     }
 }

--- a/server/src/test/java/ppalatjyo/server/global/dto/handler/GlobalExceptionHandlerTest.java
+++ b/server/src/test/java/ppalatjyo/server/global/dto/handler/GlobalExceptionHandlerTest.java
@@ -1,0 +1,69 @@
+package ppalatjyo.server.global.dto.handler;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@AutoConfigureRestDocs
+class GlobalExceptionHandlerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void test_noSuchElementException_handling() throws Exception {
+        mockMvc.perform(get("/test/notfound"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.status").value(404))
+                .andExpect(jsonPath("$.error.message").value("User Not Found"))
+                .andDo(document("no-such-element-exception",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        responseFields(
+                                fieldWithPath("success").description("성공 여부 (false)"),
+                                fieldWithPath("status").description("HTTP 상태 코드 (404)"),
+                                fieldWithPath("data").description("데이터 (null)"),
+                                fieldWithPath("error.message").description("에러 메시지"),
+                                fieldWithPath("error.timestamp").description("에러 발생 시간"),
+                                fieldWithPath("error.data").description("각 필드별 에러 메시지 (null)"),
+                                fieldWithPath("error.path").description("요청된 경로")
+                        )
+                ));
+    }
+
+    @Test
+    void test_exception_handling() throws Exception {
+        mockMvc.perform(get("/test/error"))
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.status").value(500))
+                .andExpect(jsonPath("$.error.message").value("Server Error"))
+                .andDo(document("internal-server-error",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        responseFields(
+                                fieldWithPath("success").description("성공 여부 (false)"),
+                                fieldWithPath("status").description("HTTP 상태 코드 (500)"),
+                                fieldWithPath("data").description("데이터 (null)"),
+                                fieldWithPath("error.message").description("에러 메시지"),
+                                fieldWithPath("error.timestamp").description("에러 발생 시간"),
+                                fieldWithPath("error.data").description("각 필드별 에러 메시지 (null)"),
+                                fieldWithPath("error.path").description("요청된 경로")
+                        )
+                ));
+    }
+}

--- a/server/src/test/java/ppalatjyo/server/lobby/LobbyTest.java
+++ b/server/src/test/java/ppalatjyo/server/lobby/LobbyTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import ppalatjyo.server.lobby.domain.Lobby;
 import ppalatjyo.server.lobby.domain.LobbyOptions;
+import ppalatjyo.server.lobby.exception.LobbyAlreadyDeletedException;
 import ppalatjyo.server.quiz.domain.Quiz;
 import ppalatjyo.server.user.domain.User;
 


### PR DESCRIPTION
## 관련 이슈

- #26 

## 변경 사항

- `NoSuchElementException` 예외에 대해서 각 도메인에 해당하는 커스텀 예외를 작성하였습니다.
  - 예) `UserNotFoundException`
  - 각 자식 예외 클래스는 어느 도메인에 대한 예외인지 예외 메시지를 생성자로 추가했습니다.
- `NoSuchElementException` 을 처리하는 전역 핸들러를 작성하였습니다.
  - 404 Not Found와 함께 어느 도메인이 없는지 예외 메시지를 함께 반환합니다.
- 나머지 `Exception`에 대해 500 Internal Server Error를 반환하는 핸들러를 작성하였습니다.
- 각 예외는 ResponseDto 형식으로 반환됩니다.
- 반환에 대한 테스트 컨트롤러와 테스트를 작성하였습니다.
- REST Docs에 문서화하였습니다.

## 고려 사항 및 주의 사항 (선택)

## 추가 정보 (선택)
