### PR TITLE
[FEATURE #59]: 문제 제시 이벤트 구현

### DIFF
--- a/server/src/main/java/ppalatjyo/server/game/GameEventHandler.java
+++ b/server/src/main/java/ppalatjyo/server/game/GameEventHandler.java
@@ -1,28 +1,35 @@
 package ppalatjyo.server.game;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
+import ppalatjyo.server.game.domain.Game;
 import ppalatjyo.server.game.dto.GameEventDto;
+import ppalatjyo.server.game.dto.GameStartedEventDto;
+import ppalatjyo.server.game.dto.PresentQuestionEventDto;
 import ppalatjyo.server.game.event.GameEndedEvent;
 import ppalatjyo.server.game.event.GameStartedEvent;
 import ppalatjyo.server.game.event.RightAnswerEvent;
 import ppalatjyo.server.game.event.TimeOutEvent;
+import ppalatjyo.server.game.exception.GameNotFoundException;
 import ppalatjyo.server.global.scheduler.SchedulerService;
 import ppalatjyo.server.global.websocket.MessageBrokerService;
-import ppalatjyo.server.global.websocket.dto.MessagePublicationDto;
+import ppalatjyo.server.global.websocket.dto.PublicationDto;
+import ppalatjyo.server.quiz.domain.Question;
 
 /**
  * 발생한 GameEvent에 대해 핸들링합니다.
  * 메시지 발행과 타이머 스레드 생성을 관리합니다.
- * 기본적으로 모든 트랜잭션이 커밋되고 난 시점에 대해 다룹니다.
+ * 기본적으로 모든 서비스 트랜잭션이 커밋되고 난 시점에 대해 다룹니다.
  */
 @Component
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class GameEventHandler {
 
+    private final GameRepository gameRepository;
     private final MessageBrokerService messageBrokerService;
     private final GameService gameService;
     private final SchedulerService schedulerService;
@@ -30,41 +37,67 @@ public class GameEventHandler {
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleGameStartedEvent(GameStartedEvent event) {
         Long gameId = event.getGameId();
+        Game game = gameRepository.findById(gameId).orElseThrow(GameNotFoundException::new);
 
-        GameEventDto data = GameEventDto.started(gameId);
-        MessagePublicationDto<GameEventDto> dto = new MessagePublicationDto<>("/games/" + gameId + "/events", data);
+        GameStartedEventDto messageDto = GameStartedEventDto.create(game);
+        PublicationDto<GameStartedEventDto> dto = new PublicationDto<>(messageDto);
 
-        messageBrokerService.publish(dto);
+        messageBrokerService.publish(getDestination(game.getLobby().getId()), dto);
 
-        schedulerService.runAfterMinutes(event.getMinPerGame(),
+        schedulerService.runAfterMinutes(game.getOptions().getSecPerQuestion(),
                 () -> gameService.end(gameId));
-        schedulerService.runAfterSecondes(event.getSecPerQuestion(),
-                () -> gameService.timeOut(gameId));
+
+        presentQuestion(game, game.getCurrentQuestion(), getDestination(game.getLobby().getId()));
+    }
+
+    /**
+     * 문제를 클라이언트에 제시하는 하는 이벤트 메시지를 발급합니다.
+     * 발급을 기준으로 타임 아웃 카운트가 시작됩니다.
+     * 타임 아웃 호출 시점에 동일한 Question인 경우 실제로 타임 아웃 처리됩니다.
+     */
+    public void presentQuestion(Game game, Question question, String destination) {
+        PresentQuestionEventDto messageDto = PresentQuestionEventDto.create(question);
+        PublicationDto<PresentQuestionEventDto> dto = new PublicationDto<>(messageDto);
+
+        messageBrokerService.publish(destination, dto);
+
+        schedulerService.runAfterSecondes(game.getOptions().getSecPerQuestion(),
+                () -> gameService.timeOut(game.getId(), question.getId()));
     }
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleGameEndedEvent(GameEndedEvent gameEndedEvent) {
         Long gameId = gameEndedEvent.getGameId();
+        Game game = gameRepository.findById(gameId).orElseThrow(GameNotFoundException::new);
 
         GameEventDto data = GameEventDto.ended(gameId);
-        MessagePublicationDto<GameEventDto> dto = new MessagePublicationDto<>("/games/" + gameId + "/events", data);
+        PublicationDto<GameEventDto> dto = new PublicationDto<>(data);
 
-        messageBrokerService.publish(dto);
+        messageBrokerService.publish(getDestination(game.getLobby().getId()), dto);
     }
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleTimeOutEvent(TimeOutEvent event) {
+        Game game = gameRepository.findById(event.getGameId()).orElseThrow(GameNotFoundException::new);
         GameEventDto data = GameEventDto.timeOut(event.getGameId());
-        MessagePublicationDto<GameEventDto> dto = new MessagePublicationDto<>("/games/" + event.getGameId() + "/events", data);
+        PublicationDto<GameEventDto> dto = new PublicationDto<>(data);
 
-        messageBrokerService.publish(dto);
+        messageBrokerService.publish(getDestination(game.getLobby().getId()), dto);
     }
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleRightAnswer(RightAnswerEvent event) {
+        Game game = gameRepository.findById(event.getGameId()).orElseThrow(GameNotFoundException::new);
         GameEventDto data = GameEventDto.rightAnswer(event.getGameId(), event.getUserId(), event.getNickname(), event.getMessageId());
-        MessagePublicationDto<GameEventDto> dto = new MessagePublicationDto<>("/games/" + event.getGameId() + "/events", data);
+        PublicationDto<GameEventDto> dto = new PublicationDto<>(data);
 
-        messageBrokerService.publish(dto);
+        messageBrokerService.publish(getDestination(game.getLobby().getId()), dto);
+    }
+
+    private String getDestination(Long lobbyId) {
+        String GAME_EVENT_DESTINATION_PREFIX = "/lobbies/";
+        String GAME_EVENT_DESTINATION_SUFFIX = "/games/events";
+
+        return GAME_EVENT_DESTINATION_PREFIX + lobbyId + GAME_EVENT_DESTINATION_SUFFIX;
     }
 }

--- a/server/src/main/java/ppalatjyo/server/game/GameService.java
+++ b/server/src/main/java/ppalatjyo/server/game/GameService.java
@@ -16,6 +16,9 @@ import ppalatjyo.server.message.MessageNotFoundException;
 import ppalatjyo.server.message.MessageService;
 import ppalatjyo.server.message.domain.Message;
 import ppalatjyo.server.message.MessageRepository;
+import ppalatjyo.server.quiz.domain.Question;
+import ppalatjyo.server.quiz.exception.QuestionNotFoundException;
+import ppalatjyo.server.quiz.repository.QuestionRepository;
 import ppalatjyo.server.usergame.UserGame;
 import ppalatjyo.server.usergame.UserGameNotFoundException;
 import ppalatjyo.server.usergame.UserGameRepository;
@@ -29,6 +32,7 @@ public class GameService {
     private final LobbyRepository lobbyRepository;
     private final UserGameRepository userGameRepository;
     private final MessageRepository messageRepository;
+    private final QuestionRepository questionRepository;
     private final GameRepository gameRepository;
     private final GameLogService gameLogService;
     private final MessageService messageService;
@@ -44,10 +48,7 @@ public class GameService {
 
         messageService.sendSystemMessage("게임이 시작되었습니다.", lobbyId);
 
-        eventPublisher.publishEvent(new GameStartedEvent(
-                game.getId(),
-                game.getOptions().getMinPerGame(),
-                game.getOptions().getSecPerQuestion()));
+        eventPublisher.publishEvent(new GameStartedEvent(game.getId()));
     }
 
     public void nextQuestion(Long gameId) {
@@ -75,10 +76,24 @@ public class GameService {
         eventPublisher.publishEvent(new GameEndedEvent(game.getId()));
     }
 
-    public void timeOut(Long gameId) {
+    /**
+     * 문제가 제시되고 정해진 시간이 지나면 호출됩니다. 현재 게임이 이미 종료되었거나, 타임 아웃된 문제가 현재 문제가 아니라면(이미 다음
+     * 문제로 넘어갔다면) 조기에 리턴됩니다. 타임 아웃이 확인되면 이벤트를 발행하고 내부 {@code nextQuestion()}을 호출합니다.
+     *
+     * @param gameId 게임 ID
+     * @param questionId 타임 아웃된 문제 ID
+     */
+    public void timeOut(Long gameId, Long questionId) {
         Game game = gameRepository.findById(gameId).orElseThrow(GameNotFoundException::new);
 
         if (game.isEnded()) {
+            return;
+        }
+
+        Question currentQuestion = game.getCurrentQuestion();
+        Question timedOutQuestion = questionRepository.findById(questionId).orElseThrow(QuestionNotFoundException::new);
+
+        if (!currentQuestion.equals(timedOutQuestion)) {
             return;
         }
 
@@ -86,12 +101,7 @@ public class GameService {
 
         eventPublisher.publishEvent(new TimeOutEvent(gameId));
 
-        if (game.hasNextQuestion()) {
-            nextQuestion(gameId);
-            return;
-        }
-
-        end(gameId);
+        nextQuestion(gameId);
     }
 
     public void submitAnswer(SubmitAnswerRequestDto requestDto) {

--- a/server/src/main/java/ppalatjyo/server/game/dto/GameStartedEventDto.java
+++ b/server/src/main/java/ppalatjyo/server/game/dto/GameStartedEventDto.java
@@ -1,0 +1,27 @@
+package ppalatjyo.server.game.dto;
+
+import lombok.Builder;
+import lombok.Data;
+import ppalatjyo.server.game.domain.Game;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+public class GameStartedEventDto {
+    private Long gameId;
+    private Integer minPerGame;
+    private Integer secPerQuestion;
+    private Integer totalQuestion;
+    private LocalDateTime startedAt;
+
+    public static GameStartedEventDto create(Game game) {
+        return GameStartedEventDto.builder()
+                .gameId(game.getId())
+                .minPerGame(game.getOptions().getMinPerGame())
+                .secPerQuestion(game.getOptions().getSecPerQuestion())
+                .totalQuestion(game.getQuiz().getQuestions().size())
+                .startedAt(game.getStartedAt())
+                .build();
+    }
+}

--- a/server/src/main/java/ppalatjyo/server/game/dto/GameStartedEventDto.java
+++ b/server/src/main/java/ppalatjyo/server/game/dto/GameStartedEventDto.java
@@ -2,7 +2,7 @@ package ppalatjyo.server.game.dto;
 
 import lombok.Builder;
 import lombok.Data;
-import ppalatjyo.server.game.domain.Game;
+import ppalatjyo.server.game.event.GameStartedEvent;
 
 import java.time.LocalDateTime;
 
@@ -15,13 +15,13 @@ public class GameStartedEventDto {
     private Integer totalQuestion;
     private LocalDateTime startedAt;
 
-    public static GameStartedEventDto create(Game game) {
+    public static GameStartedEventDto create(GameStartedEvent event) {
         return GameStartedEventDto.builder()
-                .gameId(game.getId())
-                .minPerGame(game.getOptions().getMinPerGame())
-                .secPerQuestion(game.getOptions().getSecPerQuestion())
-                .totalQuestion(game.getQuiz().getQuestions().size())
-                .startedAt(game.getStartedAt())
+                .gameId(event.getGameId())
+                .minPerGame(event.getMinPerGame())
+                .secPerQuestion(event.getSecPerQuestion())
+                .totalQuestion(event.getTotalQuestion())
+                .startedAt(event.getStartedAt())
                 .build();
     }
 }

--- a/server/src/main/java/ppalatjyo/server/game/dto/PresentQuestionEventDto.java
+++ b/server/src/main/java/ppalatjyo/server/game/dto/PresentQuestionEventDto.java
@@ -1,0 +1,19 @@
+package ppalatjyo.server.game.dto;
+
+import lombok.Builder;
+import lombok.Data;
+import ppalatjyo.server.quiz.domain.Question;
+
+@Data
+@Builder
+public class PresentQuestionEventDto {
+    private Long questionId;
+    private String content;
+
+    public static PresentQuestionEventDto create(Question question) {
+        return PresentQuestionEventDto.builder()
+                .questionId(question.getId())
+                .content(question.getContent())
+                .build();
+    }
+}

--- a/server/src/main/java/ppalatjyo/server/game/dto/PresentQuestionEventDto.java
+++ b/server/src/main/java/ppalatjyo/server/game/dto/PresentQuestionEventDto.java
@@ -1,19 +1,11 @@
 package ppalatjyo.server.game.dto;
 
-import lombok.Builder;
+import lombok.AllArgsConstructor;
 import lombok.Data;
-import ppalatjyo.server.quiz.domain.Question;
 
 @Data
-@Builder
+@AllArgsConstructor
 public class PresentQuestionEventDto {
     private Long questionId;
     private String content;
-
-    public static PresentQuestionEventDto create(Question question) {
-        return PresentQuestionEventDto.builder()
-                .questionId(question.getId())
-                .content(question.getContent())
-                .build();
-    }
 }

--- a/server/src/main/java/ppalatjyo/server/game/event/GameEndedEvent.java
+++ b/server/src/main/java/ppalatjyo/server/game/event/GameEndedEvent.java
@@ -7,4 +7,5 @@ import lombok.Data;
 @AllArgsConstructor
 public class GameEndedEvent {
     private Long gameId;
+    private Long lobbyId;
 }

--- a/server/src/main/java/ppalatjyo/server/game/event/GameStartedEvent.java
+++ b/server/src/main/java/ppalatjyo/server/game/event/GameStartedEvent.java
@@ -7,6 +7,4 @@ import lombok.Data;
 @AllArgsConstructor
 public class GameStartedEvent {
     private Long gameId;
-    private Integer minPerGame;
-    private Integer secPerQuestion;
 }

--- a/server/src/main/java/ppalatjyo/server/game/event/GameStartedEvent.java
+++ b/server/src/main/java/ppalatjyo/server/game/event/GameStartedEvent.java
@@ -1,10 +1,37 @@
 package ppalatjyo.server.game.event;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
+import ppalatjyo.server.game.domain.Game;
+
+import java.time.LocalDateTime;
 
 @Data
 @AllArgsConstructor
+@NoArgsConstructor
+@Builder
 public class GameStartedEvent {
     private Long gameId;
+    private Long lobbyId;
+    private Integer minPerGame;
+    private Integer secPerQuestion;
+    private Integer totalQuestion;
+    private LocalDateTime startedAt;
+    private Long currentQuestionId;
+    private String currentQuestionContent;
+
+    public static GameStartedEvent create(Game game) {
+        return GameStartedEvent.builder()
+                .gameId(game.getId())
+                .lobbyId(game.getLobby().getId())
+                .minPerGame(game.getOptions().getMinPerGame())
+                .secPerQuestion(game.getOptions().getSecPerQuestion())
+                .totalQuestion(game.getQuiz().getQuestions().size())
+                .startedAt(game.getStartedAt())
+                .currentQuestionId(game.getCurrentQuestion().getId())
+                .currentQuestionContent(game.getCurrentQuestion().getContent())
+                .build();
+    }
 }

--- a/server/src/main/java/ppalatjyo/server/game/event/RightAnswerEvent.java
+++ b/server/src/main/java/ppalatjyo/server/game/event/RightAnswerEvent.java
@@ -8,6 +8,7 @@ import lombok.Data;
 public class RightAnswerEvent {
     private Long gameId;
     private Long userId;
+    private Long lobbyId;
     private String nickname;
     private Long messageId;
 }

--- a/server/src/main/java/ppalatjyo/server/game/event/TimeOutEvent.java
+++ b/server/src/main/java/ppalatjyo/server/game/event/TimeOutEvent.java
@@ -7,4 +7,5 @@ import lombok.Data;
 @AllArgsConstructor
 public class TimeOutEvent {
     private Long gameId;
+    private Long lobbyId;
 }

--- a/server/src/main/java/ppalatjyo/server/global/websocket/MessageBrokerService.java
+++ b/server/src/main/java/ppalatjyo/server/global/websocket/MessageBrokerService.java
@@ -5,22 +5,29 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
-import ppalatjyo.server.global.websocket.dto.MessagePublicationDto;
+import ppalatjyo.server.global.websocket.dto.PublicationDto;
 
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class MessageBrokerService {
 
-    private static final String TOPIC_PREFIX = "/topic/";
+    private static final String TOPIC_PREFIX = "/topic";
 
     private final SimpMessagingTemplate simpMessagingTemplate;
 
-    public <T> void publish(MessagePublicationDto<T> dto){
+    /**
+     * 주어진 destination으로 메시지를 발행합니다.
+     *
+     * @param destination "/topic" 뒤에 붙을 문자열
+     * @param dto 발행 메시지 Dto
+     * @param <T> 실제 데이터 타입
+     */
+    public <T> void publish(String destination, PublicationDto<T> dto){
         try {
-            simpMessagingTemplate.convertAndSend(TOPIC_PREFIX + dto.getDestination(), dto.getData());
+            simpMessagingTemplate.convertAndSend(TOPIC_PREFIX + destination, dto.getData());
         } catch (MessagingException ex) {
-            log.error("Error sending message to {} {}", dto.getDestination(), ex.getMessage(), ex);
+            log.error("Error sending message to {} {}", destination, ex.getMessage(), ex);
         }
     }
 }

--- a/server/src/main/java/ppalatjyo/server/global/websocket/dto/PublicationDto.java
+++ b/server/src/main/java/ppalatjyo/server/global/websocket/dto/PublicationDto.java
@@ -8,9 +8,7 @@ import lombok.NoArgsConstructor;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-public class MessagePublicationDto<T> {
-    @NotNull
-    private String destination;
+public class PublicationDto<T> {
     @NotNull
     private T data;
 }

--- a/server/src/main/java/ppalatjyo/server/message/MessageEventHandler.java
+++ b/server/src/main/java/ppalatjyo/server/message/MessageEventHandler.java
@@ -26,11 +26,9 @@ public class MessageEventHandler {
 
         MessageDto messageDto = MessageDto.chatMessage(message);
 
-        PublicationDto<MessageDto> publicationDto = new PublicationDto<>();
-        publicationDto.setDestination("lobbies/" + message.getLobby().getId() + "/messages/new");
-        publicationDto.setData(messageDto);
+        PublicationDto<MessageDto> publicationDto = new PublicationDto<>(messageDto);
 
-        messageBrokerService.publish(publicationDto);
+        messageBrokerService.publish(getDestination(message.getLobby().getId()),publicationDto);
     }
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
@@ -39,10 +37,14 @@ public class MessageEventHandler {
 
         MessageDto messageDto = MessageDto.systemMessage(message);
 
-        PublicationDto<MessageDto> publicationDto = new PublicationDto<>();
-        publicationDto.setDestination("lobbies/" + message.getLobby().getId() + "/messages/new");
-        publicationDto.setData(messageDto);
+        PublicationDto<MessageDto> publicationDto = new PublicationDto<>(messageDto);
 
-        messageBrokerService.publish(publicationDto);
+        messageBrokerService.publish(getDestination(message.getLobby().getId()), publicationDto);
+    }
+
+    private String getDestination(Long lobbyId) {
+        String MESSAGE_EVENT_DESTINATION_PREFIX = "/lobbies/";
+        String MESSAGE_EVENT_DESTINATION_SUFFIX = "/messages/new";
+        return MESSAGE_EVENT_DESTINATION_PREFIX + lobbyId + MESSAGE_EVENT_DESTINATION_SUFFIX;
     }
 }

--- a/server/src/main/java/ppalatjyo/server/message/MessageEventHandler.java
+++ b/server/src/main/java/ppalatjyo/server/message/MessageEventHandler.java
@@ -5,7 +5,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 import ppalatjyo.server.global.websocket.MessageBrokerService;
-import ppalatjyo.server.global.websocket.dto.MessagePublicationDto;
+import ppalatjyo.server.global.websocket.dto.PublicationDto;
 import ppalatjyo.server.message.domain.Message;
 import ppalatjyo.server.message.event.ChatMessageSentEvent;
 import ppalatjyo.server.message.event.SystemMessageSentEvent;
@@ -26,7 +26,7 @@ public class MessageEventHandler {
 
         MessageDto messageDto = MessageDto.chatMessage(message);
 
-        MessagePublicationDto<MessageDto> publicationDto = new MessagePublicationDto<>();
+        PublicationDto<MessageDto> publicationDto = new PublicationDto<>();
         publicationDto.setDestination("lobbies/" + message.getLobby().getId() + "/messages/new");
         publicationDto.setData(messageDto);
 
@@ -39,7 +39,7 @@ public class MessageEventHandler {
 
         MessageDto messageDto = MessageDto.systemMessage(message);
 
-        MessagePublicationDto<MessageDto> publicationDto = new MessagePublicationDto<>();
+        PublicationDto<MessageDto> publicationDto = new PublicationDto<>();
         publicationDto.setDestination("lobbies/" + message.getLobby().getId() + "/messages/new");
         publicationDto.setData(messageDto);
 

--- a/server/src/test/java/ppalatjyo/server/game/GameEventHandlerTest.java
+++ b/server/src/test/java/ppalatjyo/server/game/GameEventHandlerTest.java
@@ -13,9 +13,8 @@ import ppalatjyo.server.game.event.TimeOutEvent;
 import ppalatjyo.server.global.scheduler.SchedulerService;
 import ppalatjyo.server.global.websocket.MessageBrokerService;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.Mockito.verify;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class GameEventHandlerTest {
@@ -33,63 +32,52 @@ class GameEventHandlerTest {
     @DisplayName("게임 시작 이벤트")
     void gameStartedEvent() {
         // given
-        Long gameId = 1L;
-        int minPerGame = 5;
-        int secPerQuestion = 30;
-        GameStartedEvent event = new GameStartedEvent(gameId, minPerGame, secPerQuestion);
+        GameStartedEvent event = mock(GameStartedEvent.class);
 
         // when
         gameEventHandler.handleGameStartedEvent(event);
 
         // then
-        verify(messageBrokerService).publish(any());
+        verify(messageBrokerService, times(2)).publish(anyString(), any());
         verify(schedulerService).runAfterMinutes(anyInt(), any(Runnable.class));
-        verify(schedulerService).runAfterSecondes(anyInt(), any(Runnable.class));
     }
 
     @Test
     @DisplayName("게임 종료 이벤트")
     void gameEndedEvent() {
         // given
-        Long gameId = 1L;
-        GameEndedEvent event = new GameEndedEvent(gameId);
+        GameEndedEvent event = mock(GameEndedEvent.class);
 
         // when
         gameEventHandler.handleGameEndedEvent(event);
 
         // then
-        verify(messageBrokerService).publish(any());
+        verify(messageBrokerService).publish(anyString(), any());
     }
 
     @Test
     @DisplayName("게임 타임업 이벤트")
     void gameTimeUp() {
         // given
-        Long gameId = 1L;
-        TimeOutEvent event = new TimeOutEvent(gameId);
+        TimeOutEvent event = mock(TimeOutEvent.class);
 
         // when
         gameEventHandler.handleTimeOutEvent(event);
 
         // then
-        verify(messageBrokerService).publish(any());
+        verify(messageBrokerService).publish(anyString(), any());
     }
 
     @Test
     @DisplayName("정답 이벤트")
     void rightAnswerEvent() {
         // given
-        Long gameId = 1L;
-        Long userId = 1L;
-        String nickname = "winner";
-        Long messageId = 1L;
-
-        RightAnswerEvent event = new RightAnswerEvent(gameId, userId, nickname, messageId);
+        RightAnswerEvent event = mock(RightAnswerEvent.class);
 
         // when
         gameEventHandler.handleRightAnswer(event);
 
         // then
-        verify(messageBrokerService).publish(any());
+        verify(messageBrokerService).publish(anyString(), any());
     }
 }

--- a/server/src/test/java/ppalatjyo/server/game/GameServiceTest.java
+++ b/server/src/test/java/ppalatjyo/server/game/GameServiceTest.java
@@ -21,6 +21,7 @@ import ppalatjyo.server.message.MessageRepository;
 import ppalatjyo.server.quiz.domain.Answer;
 import ppalatjyo.server.quiz.domain.Question;
 import ppalatjyo.server.quiz.domain.Quiz;
+import ppalatjyo.server.quiz.repository.QuestionRepository;
 import ppalatjyo.server.user.domain.User;
 import ppalatjyo.server.usergame.UserGame;
 import ppalatjyo.server.usergame.UserGameRepository;
@@ -37,22 +38,18 @@ class GameServiceTest {
 
     @Mock
     private GameRepository gameRepository;
-
     @Mock
     private UserGameRepository userGameRepository;
-
     @Mock
     private GameLogService gameLogService;
-
     @Mock
     private LobbyRepository lobbyRepository;
-
+    @Mock
+    private QuestionRepository questionRepository;
     @Mock
     private MessageRepository messageRepository;
-
     @Mock
     private ApplicationEventPublisher eventPublisher;
-
     @Mock
     private MessageService messageService;
 
@@ -151,10 +148,13 @@ class GameServiceTest {
         Long gameId = 1L;
         Game game = createGame(LobbyOptions.defaultOptions());
 
+        Question currentQuestion = game.getCurrentQuestion();
+
         when(gameRepository.findById(gameId)).thenReturn(Optional.of(game));
+        when(questionRepository.findById(currentQuestion.getId())).thenReturn(Optional.of(currentQuestion));
 
         // when
-        gameService.timeOut(gameId);
+        gameService.timeOut(gameId, currentQuestion.getId());
 
         // then
         verify(gameLogService).timeOut(gameId);

--- a/server/src/test/java/ppalatjyo/server/global/websocket/MessageBrokerServiceTest.java
+++ b/server/src/test/java/ppalatjyo/server/global/websocket/MessageBrokerServiceTest.java
@@ -25,18 +25,16 @@ class MessageBrokerServiceTest {
     @DisplayName("메시지 발행")
     void publish() {
         // given
-        String destination = "destination";
+        String destination = "/destination";
         TestPublicationDataDto dataDto = new TestPublicationDataDto();
         dataDto.setNickname("nickname");
         dataDto.setContent("content");
-        PublicationDto<TestPublicationDataDto> requestDto = new PublicationDto<>();
-        requestDto.setDestination(destination);
-        requestDto.setData(dataDto);
+        PublicationDto<TestPublicationDataDto> requestDto = new PublicationDto<>(dataDto);
 
         // when
-        messageBrokerService.publish(requestDto);
+        messageBrokerService.publish(destination, requestDto);
 
         // then
-        verify(simpMessagingTemplate).convertAndSend("/topic/" + destination, dataDto);
+        verify(simpMessagingTemplate).convertAndSend("/topic" + destination, dataDto);
     }
 }

--- a/server/src/test/java/ppalatjyo/server/global/websocket/MessageBrokerServiceTest.java
+++ b/server/src/test/java/ppalatjyo/server/global/websocket/MessageBrokerServiceTest.java
@@ -7,7 +7,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
-import ppalatjyo.server.global.websocket.dto.MessagePublicationDto;
+import ppalatjyo.server.global.websocket.dto.PublicationDto;
 import ppalatjyo.server.global.websocket.dto.TestPublicationDataDto;
 
 import static org.mockito.Mockito.verify;
@@ -29,7 +29,7 @@ class MessageBrokerServiceTest {
         TestPublicationDataDto dataDto = new TestPublicationDataDto();
         dataDto.setNickname("nickname");
         dataDto.setContent("content");
-        MessagePublicationDto<TestPublicationDataDto> requestDto = new MessagePublicationDto<>();
+        PublicationDto<TestPublicationDataDto> requestDto = new PublicationDto<>();
         requestDto.setDestination(destination);
         requestDto.setData(dataDto);
 

--- a/server/src/test/java/ppalatjyo/server/message/MessageEventHandlerTest.java
+++ b/server/src/test/java/ppalatjyo/server/message/MessageEventHandlerTest.java
@@ -53,7 +53,7 @@ class MessageEventHandlerTest {
         messageEventHandler.handleChatMessageSentEvent(event);
 
         // then
-        verify(messageBrokerService).publish(any(PublicationDto.class));
+        verify(messageBrokerService).publish(anyString(), any(PublicationDto.class));
     }
 
     @Test
@@ -75,6 +75,6 @@ class MessageEventHandlerTest {
         messageEventHandler.handleSystemMessageSentEvent(event);
 
         // then
-        verify(messageBrokerService).publish(any(PublicationDto.class));
+        verify(messageBrokerService).publish(anyString(), any(PublicationDto.class));
     }
 }

--- a/server/src/test/java/ppalatjyo/server/message/MessageEventHandlerTest.java
+++ b/server/src/test/java/ppalatjyo/server/message/MessageEventHandlerTest.java
@@ -7,7 +7,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import ppalatjyo.server.global.websocket.MessageBrokerService;
-import ppalatjyo.server.global.websocket.dto.MessagePublicationDto;
+import ppalatjyo.server.global.websocket.dto.PublicationDto;
 import ppalatjyo.server.lobby.domain.Lobby;
 import ppalatjyo.server.message.domain.Message;
 import ppalatjyo.server.message.event.ChatMessageSentEvent;
@@ -53,7 +53,7 @@ class MessageEventHandlerTest {
         messageEventHandler.handleChatMessageSentEvent(event);
 
         // then
-        verify(messageBrokerService).publish(any(MessagePublicationDto.class));
+        verify(messageBrokerService).publish(any(PublicationDto.class));
     }
 
     @Test
@@ -75,6 +75,6 @@ class MessageEventHandlerTest {
         messageEventHandler.handleSystemMessageSentEvent(event);
 
         // then
-        verify(messageBrokerService).publish(any(MessagePublicationDto.class));
+        verify(messageBrokerService).publish(any(PublicationDto.class));
     }
 }


### PR DESCRIPTION
## 관련 이슈

- #59 

## 변경 사항

- 게임 시작 이벤트 이후에 문제를 제시하는 이벤트 메시지 발행을 구현하였습니다.
- GameEventHandler가 DAO(Repository)를 의존하지 않도록 수정하였습니다.

## 고려 사항 및 주의 사항 (선택)

- 다음 문제로 넘어갈 때 문제 제시를 구현해야 합니다. -> 이슈 발행 바람.
- 다른 이벤트 핸들러 클래스도 DAO에 의존하지 않도록 수정해야 합니다.
- 발행한 이벤트를 그대로 메시지브로커 Dto로 뿌리는 건 어떤지...? 현재 Service -> Event -> Dto로 변환하는 과정이 너무 긴 것 같다는 생각이 듭니다.
  - 전체 아키텍처 리펙토링을 고려해봅니다.

## 추가 정보 (선택)
