### PR TITLE
[FEATURE #70]: 다음 문제 제시 구현

### DIFF
--- a/server/src/main/java/ppalatjyo/server/game/GameEventHandler.java
+++ b/server/src/main/java/ppalatjyo/server/game/GameEventHandler.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
+import ppalatjyo.server.game.dto.AnswerInfoDto;
 import ppalatjyo.server.game.dto.GameEventDto;
 import ppalatjyo.server.game.dto.GameInfoDto;
 import ppalatjyo.server.game.dto.NewQuestionDto;
@@ -29,8 +30,9 @@ public class GameEventHandler {
     public void handleGameStartedEvent(GameStartedEvent event) {
         Long gameId = event.getGameId();
 
-        GameInfoDto eventDto = GameInfoDto.create(event);
-        PublicationDto<GameInfoDto> dto = new PublicationDto<>(eventDto);
+        GameInfoDto gameInfoDto = GameInfoDto.create(event);
+        GameEventDto gameEventDto = GameEventDto.started(gameInfoDto);
+        PublicationDto<GameEventDto> dto = new PublicationDto<>(gameEventDto);
 
         messageBrokerService.publish(getDestination(event.getLobbyId()), dto);
 
@@ -69,9 +71,7 @@ public class GameEventHandler {
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleGameEndedEvent(GameEndedEvent event) {
-        Long gameId = event.getGameId();
-
-        GameEventDto data = GameEventDto.ended(gameId);
+        GameEventDto data = GameEventDto.ended();
         PublicationDto<GameEventDto> dto = new PublicationDto<>(data);
 
         messageBrokerService.publish(getDestination(event.getLobbyId()), dto);
@@ -79,7 +79,7 @@ public class GameEventHandler {
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleTimeOutEvent(TimeOutEvent event) {
-        GameEventDto data = GameEventDto.timeOut(event.getGameId());
+        GameEventDto data = GameEventDto.timeOut(AnswerInfoDto.create(event));
         PublicationDto<GameEventDto> dto = new PublicationDto<>(data);
 
         messageBrokerService.publish(getDestination(event.getLobbyId()), dto);
@@ -87,7 +87,7 @@ public class GameEventHandler {
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleRightAnswer(RightAnswerEvent event) {
-        GameEventDto data = GameEventDto.rightAnswer(event.getGameId(), event.getUserId(), event.getNickname(), event.getMessageId());
+        GameEventDto data = GameEventDto.correct(AnswerInfoDto.create(event));
         PublicationDto<GameEventDto> dto = new PublicationDto<>(data);
 
         messageBrokerService.publish(getDestination(event.getLobbyId()), dto);

--- a/server/src/main/java/ppalatjyo/server/game/GameService.java
+++ b/server/src/main/java/ppalatjyo/server/game/GameService.java
@@ -101,7 +101,7 @@ public class GameService {
 
         gameLogService.timeOut(gameId);
 
-        eventPublisher.publishEvent(new TimeOutEvent(gameId, game.getLobby().getId()));
+        eventPublisher.publishEvent(TimeOutEvent.create(game, timedOutQuestion));
 
         nextQuestion(gameId);
     }
@@ -110,12 +110,12 @@ public class GameService {
         Game game = gameRepository.findById(requestDto.getGameId()).orElseThrow(GameNotFoundException::new);
         UserGame userGame = userGameRepository.findById(requestDto.getUserGameId()).orElseThrow(UserGameNotFoundException::new);
         Message message = messageRepository.findById(requestDto.getMessageId()).orElseThrow(MessageNotFoundException::new);
-
-        boolean isCorrect = game.getCurrentQuestion().isCorrect(message.getContent());
+        Question currentQuestion = game.getCurrentQuestion();
+        boolean isCorrect = currentQuestion.isCorrect(message.getContent());
         if (isCorrect) {
             gameLogService.rightAnswer(game.getId(), userGame.getId(), requestDto.getMessageId());
 
-            eventPublisher.publishEvent(new RightAnswerEvent(game.getId(), userGame.getId(), game.getLobby().getId(), userGame.getUser().getNickname(), requestDto.getMessageId()));
+            eventPublisher.publishEvent(RightAnswerEvent.create(game, message, currentQuestion));
 
             userGame.increaseScoreBy(1); // 현재 1점으로 고정
 

--- a/server/src/main/java/ppalatjyo/server/game/GameService.java
+++ b/server/src/main/java/ppalatjyo/server/game/GameService.java
@@ -63,7 +63,7 @@ public class GameService {
 
         game.nextQuestion();
 
-        eventPublisher.publishEvent(new NextQuestionEvent(game.getId()));
+        eventPublisher.publishEvent(NextQuestionEvent.create(game));
     }
 
     public void end(Long gameId) {

--- a/server/src/main/java/ppalatjyo/server/game/dto/AnswerInfoDto.java
+++ b/server/src/main/java/ppalatjyo/server/game/dto/AnswerInfoDto.java
@@ -1,0 +1,11 @@
+package ppalatjyo.server.game.dto;
+
+import lombok.Data;
+
+@Data
+public class AnswerInfoDto {
+    private String answer;
+    private Long correctUserId;
+    private String correctUserNickname;
+    private Long messageId;
+}

--- a/server/src/main/java/ppalatjyo/server/game/dto/AnswerInfoDto.java
+++ b/server/src/main/java/ppalatjyo/server/game/dto/AnswerInfoDto.java
@@ -1,11 +1,33 @@
 package ppalatjyo.server.game.dto;
 
+import lombok.Builder;
 import lombok.Data;
+import ppalatjyo.server.game.event.RightAnswerEvent;
+import ppalatjyo.server.game.event.TimeOutEvent;
+
+import java.util.List;
 
 @Data
+@Builder
 public class AnswerInfoDto {
-    private String answer;
+    private Long answerId;
+    private List<String> answers;
     private Long correctUserId;
     private String correctUserNickname;
     private Long messageId;
+
+    public static AnswerInfoDto create(TimeOutEvent event) {
+        return AnswerInfoDto.builder()
+                .answers(event.getAnswers())
+                .build();
+    }
+
+    public static AnswerInfoDto create(RightAnswerEvent event) {
+        return AnswerInfoDto.builder()
+                .answers(event.getAnswers())
+                .correctUserId(event.getUserId())
+                .correctUserNickname(event.getUserNickname())
+                .messageId(event.getMessageId())
+                .build();
+    }
 }

--- a/server/src/main/java/ppalatjyo/server/game/dto/GameEventDto.java
+++ b/server/src/main/java/ppalatjyo/server/game/dto/GameEventDto.java
@@ -5,11 +5,25 @@ import lombok.Data;
 
 import java.time.LocalDateTime;
 
+/**
+ * {@code /lobbies/{lobbyId}/game/events} 에 발행되는 이벤트 메시지 DTO. 각 타입에 따라 포함되는 데이터가 구분됩니다.
+ */
 @Data
 @Builder
 public class GameEventDto {
-    private Long gameId;
     private GameEventType type;
+
+    private GameInfoDto gameInfo;
+    private NewQuestionDto newQuestion;
+    private AnswerInfoDto answerInfo;
+
+    private Long gameId;
+
+    private Integer minPerGame;
+    private Integer secPerQuestion;
+    private Integer totalQuestion;
+
+
     private Long userId; // 정답자 아이디
     private String nickname; // 정답자 닉네임
     private Long messageId; // 정답 메시지 아이디
@@ -44,6 +58,14 @@ public class GameEventDto {
                 .userId(userId)
                 .nickname(nickname)
                 .messageId(messageId)
+                .build();
+    }
+
+    public static GameEventDto newQuestion(NewQuestionDto newQuestion) {
+        return GameEventDto.builder()
+                .type(GameEventType.NEW_QUESTION)
+                .newQuestion(newQuestion)
+                .publishedAt(LocalDateTime.now())
                 .build();
     }
 }

--- a/server/src/main/java/ppalatjyo/server/game/dto/GameEventDto.java
+++ b/server/src/main/java/ppalatjyo/server/game/dto/GameEventDto.java
@@ -17,47 +17,33 @@ public class GameEventDto {
     private NewQuestionDto newQuestion;
     private AnswerInfoDto answerInfo;
 
-    private Long gameId;
-
-    private Integer minPerGame;
-    private Integer secPerQuestion;
-    private Integer totalQuestion;
-
-
-    private Long userId; // 정답자 아이디
-    private String nickname; // 정답자 닉네임
-    private Long messageId; // 정답 메시지 아이디
     @Builder.Default
     private LocalDateTime publishedAt = LocalDateTime.now();
 
-    public static GameEventDto started(Long gameId) {
+    public static GameEventDto started(GameInfoDto gameInfo) {
         return GameEventDto.builder()
-                .gameId(gameId)
+                .gameInfo(gameInfo)
                 .type(GameEventType.GAME_STARTED)
                 .build();
     }
 
-    public static GameEventDto ended(Long gameId) {
+    public static GameEventDto ended() {
         return GameEventDto.builder()
-                .gameId(gameId)
                 .type(GameEventType.GAME_ENDED)
                 .build();
     }
 
-    public static GameEventDto timeOut(Long gameId) {
+    public static GameEventDto timeOut(AnswerInfoDto answerInfo) {
         return GameEventDto.builder()
-                .gameId(gameId)
+                .answerInfo(answerInfo)
                 .type(GameEventType.TIME_OUT)
                 .build();
     }
 
-    public static GameEventDto rightAnswer(Long gameId, Long userId, String nickname, Long messageId) {
+    public static GameEventDto correct(AnswerInfoDto answerInfo) {
         return GameEventDto.builder()
-                .gameId(gameId)
-                .type(GameEventType.RIGHT_ANSWER)
-                .userId(userId)
-                .nickname(nickname)
-                .messageId(messageId)
+                .type(GameEventType.CORRECT)
+                .answerInfo(answerInfo)
                 .build();
     }
 
@@ -65,7 +51,6 @@ public class GameEventDto {
         return GameEventDto.builder()
                 .type(GameEventType.NEW_QUESTION)
                 .newQuestion(newQuestion)
-                .publishedAt(LocalDateTime.now())
                 .build();
     }
 }

--- a/server/src/main/java/ppalatjyo/server/game/dto/GameEventType.java
+++ b/server/src/main/java/ppalatjyo/server/game/dto/GameEventType.java
@@ -1,5 +1,11 @@
 package ppalatjyo.server.game.dto;
 
 public enum GameEventType {
-    GAME_STARTED, GAME_ENDED, WRONG_ANSWER, RIGHT_ANSWER, TIME_OUT
+    GAME_STARTED,
+    GAME_ENDED,
+    WRONG_ANSWER,
+    RIGHT_ANSWER,
+    TIME_OUT,
+    NEW_QUESTION,
+    REVEAL_ANSWER
 }

--- a/server/src/main/java/ppalatjyo/server/game/dto/GameEventType.java
+++ b/server/src/main/java/ppalatjyo/server/game/dto/GameEventType.java
@@ -4,7 +4,7 @@ public enum GameEventType {
     GAME_STARTED,
     GAME_ENDED,
     WRONG_ANSWER,
-    RIGHT_ANSWER,
+    CORRECT,
     TIME_OUT,
     NEW_QUESTION,
     REVEAL_ANSWER

--- a/server/src/main/java/ppalatjyo/server/game/dto/GameInfoDto.java
+++ b/server/src/main/java/ppalatjyo/server/game/dto/GameInfoDto.java
@@ -8,15 +8,15 @@ import java.time.LocalDateTime;
 
 @Data
 @Builder
-public class GameStartedEventDto {
+public class GameInfoDto {
     private Long gameId;
     private Integer minPerGame;
     private Integer secPerQuestion;
     private Integer totalQuestion;
     private LocalDateTime startedAt;
 
-    public static GameStartedEventDto create(GameStartedEvent event) {
-        return GameStartedEventDto.builder()
+    public static GameInfoDto create(GameStartedEvent event) {
+        return GameInfoDto.builder()
                 .gameId(event.getGameId())
                 .minPerGame(event.getMinPerGame())
                 .secPerQuestion(event.getSecPerQuestion())

--- a/server/src/main/java/ppalatjyo/server/game/dto/NewQuestionDto.java
+++ b/server/src/main/java/ppalatjyo/server/game/dto/NewQuestionDto.java
@@ -5,7 +5,7 @@ import lombok.Data;
 
 @Data
 @AllArgsConstructor
-public class PresentQuestionEventDto {
+public class NewQuestionDto {
     private Long questionId;
     private String content;
 }

--- a/server/src/main/java/ppalatjyo/server/game/event/NextQuestionEvent.java
+++ b/server/src/main/java/ppalatjyo/server/game/event/NextQuestionEvent.java
@@ -1,10 +1,28 @@
 package ppalatjyo.server.game.event;
 
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import ppalatjyo.server.game.domain.Game;
 
 @Data
-@AllArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
 public class NextQuestionEvent {
+    private Long lobbyId;
     private Long gameId;
+    private Long questionId;
+    private String questionContent;
+    private int secPerQuestion;
+
+    public static NextQuestionEvent create(Game game) {
+        return NextQuestionEvent.builder()
+                .lobbyId(game.getLobby().getId())
+                .gameId(game.getId())
+                .questionId(game.getCurrentQuestion().getId())
+                .questionContent(game.getCurrentQuestion().getContent())
+                .secPerQuestion(game.getOptions().getSecPerQuestion())
+                .build();
+    }
 }

--- a/server/src/main/java/ppalatjyo/server/game/event/RightAnswerEvent.java
+++ b/server/src/main/java/ppalatjyo/server/game/event/RightAnswerEvent.java
@@ -1,14 +1,34 @@
 package ppalatjyo.server.game.event;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import ppalatjyo.server.game.domain.Game;
+import ppalatjyo.server.message.domain.Message;
+import ppalatjyo.server.quiz.domain.Answer;
+import ppalatjyo.server.quiz.domain.Question;
+
+import java.util.List;
 
 @Data
 @AllArgsConstructor
+@Builder
 public class RightAnswerEvent {
+    private Long lobbyId;
     private Long gameId;
     private Long userId;
-    private Long lobbyId;
-    private String nickname;
+    private String userNickname;
     private Long messageId;
+    private List<String> answers;
+
+    public static RightAnswerEvent create(Game game, Message message, Question question) {
+        return RightAnswerEvent.builder()
+                .lobbyId(game.getLobby().getId())
+                .gameId(game.getId())
+                .userId(message.getUser().getId())
+                .userNickname(message.getUser().getNickname())
+                .messageId(message.getId())
+                .answers(question.getAnswers().stream().map(Answer::getContent).toList())
+                .build();
+    }
 }

--- a/server/src/main/java/ppalatjyo/server/game/event/TimeOutEvent.java
+++ b/server/src/main/java/ppalatjyo/server/game/event/TimeOutEvent.java
@@ -1,11 +1,27 @@
 package ppalatjyo.server.game.event;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import ppalatjyo.server.game.domain.Game;
+import ppalatjyo.server.quiz.domain.Answer;
+import ppalatjyo.server.quiz.domain.Question;
+
+import java.util.List;
 
 @Data
 @AllArgsConstructor
+@Builder
 public class TimeOutEvent {
     private Long gameId;
     private Long lobbyId;
+    private List<String> answers;
+
+    public static TimeOutEvent create(Game game, Question question) {
+        return TimeOutEvent.builder()
+                .gameId(game.getId())
+                .lobbyId(game.getLobby().getId())
+                .answers(question.getAnswers().stream().map(Answer::getContent).toList())
+                .build();
+    }
 }

--- a/server/src/test/java/ppalatjyo/server/game/GameEventHandlerTest.java
+++ b/server/src/test/java/ppalatjyo/server/game/GameEventHandlerTest.java
@@ -6,10 +6,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import ppalatjyo.server.game.event.GameEndedEvent;
-import ppalatjyo.server.game.event.GameStartedEvent;
-import ppalatjyo.server.game.event.RightAnswerEvent;
-import ppalatjyo.server.game.event.TimeOutEvent;
+import ppalatjyo.server.game.event.*;
 import ppalatjyo.server.global.scheduler.SchedulerService;
 import ppalatjyo.server.global.websocket.MessageBrokerService;
 
@@ -76,6 +73,19 @@ class GameEventHandlerTest {
 
         // when
         gameEventHandler.handleRightAnswer(event);
+
+        // then
+        verify(messageBrokerService).publish(anyString(), any());
+    }
+
+    @Test
+    @DisplayName("NextQuestionEvent")
+    void handleNextQuestionEvent() {
+        // given
+        NextQuestionEvent event = mock(NextQuestionEvent.class);
+
+        // when
+        gameEventHandler.handleNextQuestionEvent(event);
 
         // then
         verify(messageBrokerService).publish(anyString(), any());


### PR DESCRIPTION
## 관련 이슈

- #70 

## 변경 사항

- `GameEventHandler`에 `NextQuestionEvent`를 핸들링하는 메서드 `handleNextQuestionEvent()`를 구현하였습니다.
- 기존의 `publishNewQuestion()`(이전 이름: `presentQuestion()`)을 활용하도록 구현하였습니다.
- 중구난방하던 응답 형식을 GameEventDto로 통일하였습니다.
- GameEventType에 따라 포함하는 데이터가 다르도록 구현하였습니다.
- 모든 이벤트 메시지는 `/lobbies/{lobbyId}/games/events`에 발행됩니다.

## 고려 사항 및 주의 사항 (선택)

## 추가 정보 (선택)
