### PR TITLE
[FEATURE #62]: 게임 시작 후 첫 문제 제시 이벤트까지 대기 시간 구현

### DIFF
--- a/server/src/main/java/ppalatjyo/server/game/event/GameStartedEvent.java
+++ b/server/src/main/java/ppalatjyo/server/game/event/GameStartedEvent.java
@@ -19,8 +19,8 @@ public class GameStartedEvent {
     private Integer secPerQuestion;
     private Integer totalQuestion;
     private LocalDateTime startedAt;
-    private Long currentQuestionId;
-    private String currentQuestionContent;
+    private Long firstQuestionId;
+    private String firstQuestionContent;
 
     public static GameStartedEvent create(Game game) {
         return GameStartedEvent.builder()
@@ -30,8 +30,8 @@ public class GameStartedEvent {
                 .secPerQuestion(game.getOptions().getSecPerQuestion())
                 .totalQuestion(game.getQuiz().getQuestions().size())
                 .startedAt(game.getStartedAt())
-                .currentQuestionId(game.getCurrentQuestion().getId())
-                .currentQuestionContent(game.getCurrentQuestion().getContent())
+                .firstQuestionId(game.getCurrentQuestion().getId())
+                .firstQuestionContent(game.getCurrentQuestion().getContent())
                 .build();
     }
 }

--- a/server/src/test/java/ppalatjyo/server/game/GameEventHandlerTest.java
+++ b/server/src/test/java/ppalatjyo/server/game/GameEventHandlerTest.java
@@ -35,8 +35,9 @@ class GameEventHandlerTest {
         gameEventHandler.handleGameStartedEvent(event);
 
         // then
-        verify(messageBrokerService, times(2)).publish(anyString(), any());
+        verify(messageBrokerService, times(1)).publish(anyString(), any());
         verify(schedulerService).runAfterMinutes(anyInt(), any(Runnable.class));
+        verify(schedulerService).runAfterSecondes(anyInt(), any(Runnable.class));
     }
 
     @Test


### PR DESCRIPTION
## 관련 이슈

- #62 

## 변경 사항

- `GameEventHandler`에서 `handleGameStartedEvent()` 메서드 내 `publishNewQuestion()` 메서드를 `SchedulerService`를 통해 정해진 시간 이후에 호출되도록 수정하였습니다.

## 고려 사항 및 주의 사항 (선택)

- `GameEventHandler`가 점점 커지는 중입니다.

## 추가 정보 (선택)
