### PR TITLE
[FEATURE #61]: 정답 공개 이벤트 후 다음 문제 제시 이벤트까지 일정 시간 대기 구현

### DIFF
--- a/server/src/test/java/ppalatjyo/server/game/GameEventHandlerTest.java
+++ b/server/src/test/java/ppalatjyo/server/game/GameEventHandlerTest.java
@@ -89,6 +89,6 @@ class GameEventHandlerTest {
         gameEventHandler.handleNextQuestionEvent(event);
 
         // then
-        verify(messageBrokerService).publish(anyString(), any());
+        verify(schedulerService).runAfterSecondes(anyInt(), any());
     }
 }


### PR DESCRIPTION
## 관련 이슈

- #61 

## 변경 사항

- [handleNextQuestionEvent()가 publishNewQuestion()을 스케줄링 호출하도록 수정](https://github.com/gyehyun-bak/ppalatjyo/commit/c92efaf142732f7587ff3acf5ac41dc5e86f2d0c)하였습니다.
- 테스트를 수정하였습니다.

## 고려 사항 및 주의 사항 (선택)

## 추가 정보 (선택)
