### PR TITLE
[FEATURE #65]: 모든 유저가 로비를 나갔을 때 게임 종료

### DIFF
--- a/server/src/main/java/ppalatjyo/server/lobby/LobbyService.java
+++ b/server/src/main/java/ppalatjyo/server/lobby/LobbyService.java
@@ -3,6 +3,7 @@ package ppalatjyo.server.lobby;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import ppalatjyo.server.game.domain.Game;
 import ppalatjyo.server.lobby.domain.Lobby;
 import ppalatjyo.server.lobby.domain.LobbyOptions;
 import ppalatjyo.server.lobby.dto.MessageToLobbyRequestDto;
@@ -70,14 +71,16 @@ public class LobbyService {
     }
 
     /**
-     * User가 Lobby를 나갑니다. User가 나가고 더 이상 Lobby에 참가한 인원이 없으면 Lobby를 삭제합니다.
+     * <p> User가 Lobby를 나갑니다. User가 나가고 더 이상 Lobby에 참가한 인원이 없으면 Lobby를 삭제합니다.
+     * <p> Lobby에서 실행되는 게임을 모두 종료합니다. (진행 중인 게임이 있는 경우 끝까지 진행되지 않게 하기 위함)
      */
     public void leaveLobby(long userId, long lobbyId) {
         userLobbyService.leave(userId, lobbyId);
 
-        // 로비가 비었으면 삭제
+        // 로비가 비었으면 게임 종료 후 삭제
         Lobby lobby = lobbyRepository.findById(lobbyId).orElseThrow(LobbyNotFoundException::new);
         if (lobby.isEmpty()) {
+            lobby.getGames().forEach(Game::end);
             lobby.delete();
         }
     }

--- a/server/src/main/java/ppalatjyo/server/lobby/domain/Lobby.java
+++ b/server/src/main/java/ppalatjyo/server/lobby/domain/Lobby.java
@@ -2,6 +2,7 @@ package ppalatjyo.server.lobby.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
+import ppalatjyo.server.game.domain.Game;
 import ppalatjyo.server.global.audit.BaseEntity;
 import ppalatjyo.server.lobby.exception.LobbyAlreadyDeletedException;
 import ppalatjyo.server.quiz.domain.Quiz;
@@ -40,8 +41,11 @@ public class Lobby extends BaseEntity {
     private Quiz quiz;
 
     @Builder.Default
-    @OneToMany(mappedBy = "lobby", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "lobby", cascade = CascadeType.ALL)
     private List<UserLobby> userLobbies = new ArrayList<>();
+
+    @OneToMany(mappedBy = "lobby")
+    private List<Game> games;
 
     public static Lobby createLobby(String name, User host, Quiz quiz, LobbyOptions options) {
         Lobby lobby = Lobby.builder()
@@ -52,7 +56,7 @@ public class Lobby extends BaseEntity {
                 .options(options)
                 .build();
 
-        UserLobby userLobby = UserLobby.join(host, lobby);
+        UserLobby.join(host, lobby);
 
         return lobby;
     }

--- a/server/src/test/java/ppalatjyo/server/lobby/LobbyServiceTest.java
+++ b/server/src/test/java/ppalatjyo/server/lobby/LobbyServiceTest.java
@@ -8,6 +8,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import ppalatjyo.server.game.domain.Game;
 import ppalatjyo.server.lobby.domain.Lobby;
 import ppalatjyo.server.lobby.domain.LobbyOptions;
 import ppalatjyo.server.lobby.dto.MessageToLobbyRequestDto;
@@ -18,6 +19,7 @@ import ppalatjyo.server.user.UserRepository;
 import ppalatjyo.server.user.domain.User;
 import ppalatjyo.server.userlobby.UserLobbyService;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -223,8 +225,10 @@ class LobbyServiceTest {
         long lobbyId = 1L;
 
         Lobby lobby = Mockito.mock(Lobby.class);
+        Game game = Mockito.mock(Game.class);
         when(lobbyRepository.findById(lobbyId)).thenReturn(Optional.of(lobby));
         when(lobby.isEmpty()).thenReturn(true);
+        when(lobby.getGames()).thenReturn(List.of(game));
 
         // when
         lobbyService.leaveLobby(userId, lobbyId);
@@ -232,6 +236,7 @@ class LobbyServiceTest {
         // then
         verify(userLobbyService).leave(userId, lobbyId);
         verify(lobbyRepository).findById(lobbyId);
+        verify(game).end();
         verify(lobby).delete();
     }
 }


### PR DESCRIPTION
## 관련 이슈

- #65 

## 변경 사항

- `LobbyService`의 `leaveLobby()`에서 로비가 빈 경우 해당 로비의 모든 게임을 종료하도록 수정하였습니다.
- Lobby가 일대다 관계의 Game을 갖도록 Lobby 도메인을 수정하였습니다.

## 고려 사항 및 주의 사항 (선택)

## 추가 정보 (선택)
