### PR TITLE
[FEATURE #66]: 리더 보드(점수 보드) 실시간 업데이트 구현

### DIFF
--- a/server/src/main/java/ppalatjyo/server/game/GameEventHandler.java
+++ b/server/src/main/java/ppalatjyo/server/game/GameEventHandler.java
@@ -4,10 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
-import ppalatjyo.server.game.dto.AnswerInfoDto;
-import ppalatjyo.server.game.dto.GameEventDto;
-import ppalatjyo.server.game.dto.GameInfoDto;
-import ppalatjyo.server.game.dto.NewQuestionDto;
+import ppalatjyo.server.game.dto.*;
 import ppalatjyo.server.game.event.*;
 import ppalatjyo.server.global.scheduler.SchedulerService;
 import ppalatjyo.server.global.websocket.MessageBrokerService;
@@ -110,6 +107,16 @@ public class GameEventHandler {
         PublicationDto<GameEventDto> dto = new PublicationDto<>(data);
 
         messageBrokerService.publish(getDestination(event.getLobbyId()), dto);
+    }
+
+    /**
+     * {@code /lobbies/{lobbyId}/games/leaderboard/update} 로 현재 점수를 반영하여 내림차순으로 정렬한 {@link LeaderboardUpdateDto}를 반환합니다.
+     */
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleLeaderboardUpdateEvent(LeaderboardUpdateEvent event) {
+        String destination = "/lobbies/" + event.getLobbyId() + "/games/leaderboard/update";
+        PublicationDto<LeaderboardUpdateDto> dto = new PublicationDto<>(new LeaderboardUpdateDto(event.getLeaderboard()));
+        messageBrokerService.publish(destination, dto);
     }
 
     private String getDestination(Long lobbyId) {

--- a/server/src/main/java/ppalatjyo/server/game/dto/LeaderboardItemDto.java
+++ b/server/src/main/java/ppalatjyo/server/game/dto/LeaderboardItemDto.java
@@ -1,0 +1,21 @@
+package ppalatjyo.server.game.dto;
+
+import lombok.Builder;
+import lombok.Data;
+import ppalatjyo.server.usergame.UserGame;
+
+@Data
+@Builder
+public class LeaderboardItemDto {
+    private Long userId;
+    private String username;
+    private Integer score;
+
+    public static LeaderboardItemDto create(UserGame userGame) {
+        return LeaderboardItemDto.builder()
+                .userId(userGame.getUser().getId())
+                .username(userGame.getUser().getNickname())
+                .score(userGame.getScore())
+                .build();
+    }
+}

--- a/server/src/main/java/ppalatjyo/server/game/dto/LeaderboardUpdateDto.java
+++ b/server/src/main/java/ppalatjyo/server/game/dto/LeaderboardUpdateDto.java
@@ -1,0 +1,12 @@
+package ppalatjyo.server.game.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class LeaderboardUpdateDto {
+    private final List<LeaderboardItemDto> leaderboard;
+}

--- a/server/src/main/java/ppalatjyo/server/game/dto/SubmitAnswerRequestDto.java
+++ b/server/src/main/java/ppalatjyo/server/game/dto/SubmitAnswerRequestDto.java
@@ -5,6 +5,7 @@ import lombok.Data;
 @Data
 public class SubmitAnswerRequestDto {
     private Long gameId;
+    private Long lobbyId;
     private Long userGameId;
     private Long messageId;
 }

--- a/server/src/main/java/ppalatjyo/server/game/event/LeaderboardUpdateEvent.java
+++ b/server/src/main/java/ppalatjyo/server/game/event/LeaderboardUpdateEvent.java
@@ -1,0 +1,14 @@
+package ppalatjyo.server.game.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import ppalatjyo.server.game.dto.LeaderboardItemDto;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class LeaderboardUpdateEvent {
+    private final Long lobbyId;
+    private final List<LeaderboardItemDto> leaderboard;
+}

--- a/server/src/main/java/ppalatjyo/server/usergame/UserGameRepository.java
+++ b/server/src/main/java/ppalatjyo/server/usergame/UserGameRepository.java
@@ -2,5 +2,8 @@ package ppalatjyo.server.usergame;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface UserGameRepository extends JpaRepository<UserGame, Long> {
+    List<UserGame> findByGameIdOrderByScoreDesc(Long gameId);
 }

--- a/server/src/test/java/ppalatjyo/server/game/GameEventHandlerTest.java
+++ b/server/src/test/java/ppalatjyo/server/game/GameEventHandlerTest.java
@@ -91,4 +91,17 @@ class GameEventHandlerTest {
         // then
         verify(schedulerService).runAfterSecondes(anyInt(), any());
     }
+
+    @Test
+    @DisplayName("LeaderboardUpdateEvent")
+    void handleLeaderboardUpdateEvent() {
+        // given
+        LeaderboardUpdateEvent event = mock(LeaderboardUpdateEvent.class);
+
+        // when
+        gameEventHandler.handleLeaderboardUpdateEvent(event);
+
+        // then
+        verify(messageBrokerService).publish(anyString(), any());
+    }
 }


### PR DESCRIPTION
## 관련 이슈

- #66 

## 변경 사항

- `GameService`의 `submitAnswer()`에서 리더보드를 쿼리해 업데이트로 발행,
- `GameEventHandler`에서 `LeaderboardUpdateEvent`를 받아 `/lobbies/{lobbyId}/games/leaderboard/update`에 전체 리더보드 리스트를 반환하도록 구현하였습니다.

## 고려 사항 및 주의 사항 (선택)

- `GameService`와 `GameEventHandler`의 역할이 너무 커진게 아닌가 싶습니다.
- 리펙토링 고려가 필요합니다.
- 메서드가 하는 일이 많아서 테스트 하기도 어렵습니다.

## 추가 정보 (선택)
