### PR TITLE
[BUG #71]: JwtAuthenticationFilter에서 던져지는 예외는 잡을 수 없는 문제

### DIFF
--- a/server/src/main/java/ppalatjyo/server/global/security/handler/CustomAccessDeniedHandler.java
+++ b/server/src/main/java/ppalatjyo/server/global/security/handler/CustomAccessDeniedHandler.java
@@ -24,8 +24,8 @@ public class CustomAccessDeniedHandler implements AccessDeniedHandler {
     public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
         log.debug("Authentication Failed", accessDeniedException);
 
-        String errorMessage = "Authentication Failed.";
-        HttpStatus status = HttpStatus.UNAUTHORIZED;
+        String errorMessage = "Access Denied.";
+        HttpStatus status = HttpStatus.FORBIDDEN;
         ResponseErrorDto errorDto = ResponseErrorDto.commonError(errorMessage, request.getRequestURI());
         ResponseDto<Void> responseDto = ResponseDto.error(status, errorDto).getBody();
 

--- a/server/src/main/java/ppalatjyo/server/global/security/handler/CustomAuthenticationEntryPoint.java
+++ b/server/src/main/java/ppalatjyo/server/global/security/handler/CustomAuthenticationEntryPoint.java
@@ -13,6 +13,9 @@ import ppalatjyo.server.global.dto.error.ResponseErrorDto;
 
 import java.io.IOException;
 
+/**
+ * AuthorizationFilter 에서 발생하는 AuthenticationException 혹은, Anonymous 유저에 대한 AccessDeniedException 을 처리합니다.
+ */
 @Slf4j
 @RequiredArgsConstructor
 public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {

--- a/server/src/main/java/ppalatjyo/server/global/security/jwt/JwtAuthenticationFilter.java
+++ b/server/src/main/java/ppalatjyo/server/global/security/jwt/JwtAuthenticationFilter.java
@@ -29,13 +29,18 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             return;
         }
 
-        Authentication authenticationResult = authenticationManager.authenticate(authenticationRequest);
-        if (authenticationResult == null) {
-            filterChain.doFilter(request, response);
-            return;
+        try {
+            Authentication authenticationResult = authenticationManager.authenticate(authenticationRequest);
+            if (authenticationResult == null) {
+                filterChain.doFilter(request, response);
+                return;
+            }
+
+            SecurityContextHolder.getContext().setAuthentication(authenticationResult);
+        } catch (Exception e) {
+            log.trace("Exception occurred on JwtAuthenticationFilter. This usually means request has proper Bearer header but failed to validate the token. The filter does not throw an exception out of the filter chain but simply delegates the exception strategy to AuthorizationFilter.", e);
         }
 
-        SecurityContextHolder.getContext().setAuthentication(authenticationResult);
         filterChain.doFilter(request, response);
     }
 }


### PR DESCRIPTION
## 관련 이슈

- #71 

## 변경 사항

- [`CustomAccessDeniedHandler`의 응답을 401 -> 403 으로 변경](https://github.com/gyehyun-bak/ppalatjyo/commit/63224182aeb3541fdab9a19716bbbf35628d70ae)하였습니다.
  - Anonymous 유저에 대한 AccessDeniedException은 AuthenticationEntryPoint로 처리되기 때문입니다.
- [`JwtAuthenticationFilter`에서 `AuthenticationManager`의 예외를 던지지 않고 잡아서 로그를 남기고 나머지 필터 체인을 호출](https://github.com/gyehyun-bak/ppalatjyo/commit/1bf9b7697a4874e92212d5f4fe79ffa700b311ff)하도록 수정하였습니다.

## 스크린샷

<img width="1007" alt="image" src="https://github.com/user-attachments/assets/9cbe544f-33ef-4086-ac74-6b0d3eaa1ad2" />

- 유효하지 않은 토큰에 대해서도 같은 응답 형식으로 반환되는 것을 확인하였습니다.

## 고려 사항 및 주의 사항 (선택)

## 추가 정보 (선택)
