### PR TITLE
[REFACTOR #101]: 토큰 재발행 요청 시 RefreshToken이 없는 경우 403 Forbidden 반환하도록 수정

### DIFF
--- a/server/src/main/java/ppalatjyo/server/global/auth/AuthController.java
+++ b/server/src/main/java/ppalatjyo/server/global/auth/AuthController.java
@@ -25,11 +25,6 @@ public class AuthController {
 
     @GetMapping("/tokens")
     public ResponseEntity<?> reissueTokens(@CookieValue(value = "refreshToken", required = false) String refreshToken, HttpServletResponse response) {
-        if (refreshToken == null) {
-            ResponseErrorDto errorDto = ResponseErrorDto.commonError("RefreshToken Not Found", "/api/auth/tokens");
-            return ResponseDto.error(HttpStatus.UNAUTHORIZED, errorDto);
-        }
-
         return ResponseDto.ok(authService.reissue(refreshToken, response));
     }
 }

--- a/server/src/main/java/ppalatjyo/server/global/auth/AuthControllerAdvice.java
+++ b/server/src/main/java/ppalatjyo/server/global/auth/AuthControllerAdvice.java
@@ -1,0 +1,18 @@
+package ppalatjyo.server.global.auth;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import ppalatjyo.server.global.dto.ResponseDto;
+import ppalatjyo.server.global.dto.error.ResponseErrorDto;
+
+@RestControllerAdvice(assignableTypes = {AuthController.class})
+public class AuthControllerAdvice {
+
+    @ExceptionHandler(RefreshTokenException.class)
+    public ResponseEntity<ResponseDto<Void>> handleRefreshTokenException() {
+        ResponseErrorDto errorDto = ResponseErrorDto.commonError("Refresh Failed", "/api/auth/tokens");
+        return ResponseDto.error(HttpStatus.FORBIDDEN, errorDto);
+    }
+}

--- a/server/src/main/java/ppalatjyo/server/global/auth/AuthService.java
+++ b/server/src/main/java/ppalatjyo/server/global/auth/AuthService.java
@@ -37,8 +37,8 @@ public class AuthService {
     }
 
     public TokenReissueResponseDto reissue(String oldRefreshToken, HttpServletResponse response) {
-        if (!jwtTokenProvider.validateToken(oldRefreshToken)) {
-            throw new JwtValidationException("Invalid token");
+        if (oldRefreshToken == null || !jwtTokenProvider.validateToken(oldRefreshToken)) {
+            throw new RefreshTokenException("Refresh Token is null or invalid");
         }
 
         long userId = Long.parseLong(jwtTokenProvider.getUserIdFromToken(oldRefreshToken));

--- a/server/src/main/java/ppalatjyo/server/global/auth/RefreshTokenException.java
+++ b/server/src/main/java/ppalatjyo/server/global/auth/RefreshTokenException.java
@@ -1,0 +1,7 @@
+package ppalatjyo.server.global.auth;
+
+public class RefreshTokenException extends RuntimeException {
+    public RefreshTokenException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
## 관련 이슈

- #101

## 변경 사항

- `reissueTokens()` 에서 refreshToken null 체크를 `AuthService.reissue()` 내로 옮겼습니다.
- `RefreshTokenException` 을 추가하고 `AuthControllerAdvice`를 추가하였습니다.
- `RefreshTokenException` 발생 시 `403 Forbidden` 응답을 반환하도록 구현하였습니다.

## 스크린샷

<img width="776" alt="image" src="https://github.com/user-attachments/assets/0e365deb-b026-4ad4-b111-3486d132a720" />

## 고려 사항 및 주의 사항 (선택)

## 추가 정보 (선택)
