### PR TITLE
[FEATURE #107]: Lobby의 maxUsers를 넘어 참여하지 못하도록 구현

### DIFF
--- a/server/src/main/java/ppalatjyo/server/domain/lobby/LobbyService.java
+++ b/server/src/main/java/ppalatjyo/server/domain/lobby/LobbyService.java
@@ -16,6 +16,7 @@ import ppalatjyo.server.domain.user.UserRepository;
 import ppalatjyo.server.domain.user.domain.User;
 import ppalatjyo.server.domain.user.exception.UserNotFoundException;
 import ppalatjyo.server.domain.userlobby.UserLobbyService;
+import ppalatjyo.server.domain.userlobby.exception.LobbyIsFullException;
 
 @Service
 @RequiredArgsConstructor
@@ -65,8 +66,10 @@ public class LobbyService {
         messageService.sendChatMessage(requestDto.getContent(), requestDto.getUserId(), requestDto.getLobbyId());
     }
 
-    // UserLobbyService로 위임
-    public void joinLobby(long userId, long lobbyId) {
+    /**
+     * Lobby에 참가합니다. {@link UserLobbyService}로 위임합니다. 로비가 이미 가득 찬 경우 {@link LobbyIsFullException}을 던집니다.
+     */
+    public void joinLobby(long userId, long lobbyId) throws LobbyIsFullException {
         userLobbyService.join(userId, lobbyId);
     }
 

--- a/server/src/main/java/ppalatjyo/server/domain/userlobby/UserLobbyRepository.java
+++ b/server/src/main/java/ppalatjyo/server/domain/userlobby/UserLobbyRepository.java
@@ -9,4 +9,8 @@ public interface UserLobbyRepository extends JpaRepository<UserLobby, Long> {
     Optional<UserLobby> findByUserIdAndLobbyId(Long userId, Long lobbyId);
 
     List<UserLobby> findByUserId(Long userId);
+
+    int countByLobbyIdAndLeftAtIsNull(Long lobbyId);
+
+    boolean existsByUserIdAndLobbyIdAndLeftAtIsNull(Long userId, Long lobbyId);
 }

--- a/server/src/main/java/ppalatjyo/server/domain/userlobby/exception/LobbyIsFullException.java
+++ b/server/src/main/java/ppalatjyo/server/domain/userlobby/exception/LobbyIsFullException.java
@@ -1,0 +1,7 @@
+package ppalatjyo.server.domain.userlobby.exception;
+
+public class LobbyIsFullException extends RuntimeException {
+    public LobbyIsFullException() {
+        super("Lobby is full.");
+    }
+}

--- a/server/src/main/java/ppalatjyo/server/domain/userlobby/exception/UserLobbyNotFoundException.java
+++ b/server/src/main/java/ppalatjyo/server/domain/userlobby/exception/UserLobbyNotFoundException.java
@@ -1,4 +1,4 @@
-package ppalatjyo.server.domain.userlobby;
+package ppalatjyo.server.domain.userlobby.exception;
 
 import java.util.NoSuchElementException;
 


### PR DESCRIPTION
## 관련 이슈

- #107 

## 변경 사항

- `UserLobbyService`의 `join()`을 수정하였습니다.
  - 이미 참가 중인 유저라면 무시하고 리턴합니다.
  - 로비가 꽉 찬 경우 `LobbyIsFullException`을 던집니다.
- 현재 참가와 로비에 참여 중인(나가지 않은) 유저의 수를 구하는 메서드를 `UserLobbyRepository`에 추가하였습니다.
- 관련 테스트를 추가하였습니다.

## 고려 사항 및 주의 사항 (선택)

## 추가 정보 (선택)
