### PR TITLE
[FEATURE #108]: Lobby에 비밀번호 추가

### DIFF
--- a/server/src/main/java/ppalatjyo/server/domain/game/GameRepository.java
+++ b/server/src/main/java/ppalatjyo/server/domain/game/GameRepository.java
@@ -3,5 +3,8 @@ package ppalatjyo.server.domain.game;
 import org.springframework.data.jpa.repository.JpaRepository;
 import ppalatjyo.server.domain.game.domain.Game;
 
+import java.util.List;
+
 public interface GameRepository extends JpaRepository<Game, Long> {
+    List<Game> findByLobbyId(Long lobbyId);
 }

--- a/server/src/main/java/ppalatjyo/server/domain/game/GameService.java
+++ b/server/src/main/java/ppalatjyo/server/domain/game/GameService.java
@@ -165,4 +165,8 @@ public class GameService {
 
         return GAME_EVENT_DESTINATION_PREFIX + lobbyId + GAME_EVENT_DESTINATION_SUFFIX;
     }
+
+    public void endGamesByLobbyId(long lobbyId) {
+        gameRepository.findByLobbyId(lobbyId).forEach(Game::end);
+    }
 }

--- a/server/src/main/java/ppalatjyo/server/domain/lobby/LobbyService.java
+++ b/server/src/main/java/ppalatjyo/server/domain/lobby/LobbyService.java
@@ -3,7 +3,7 @@ package ppalatjyo.server.domain.lobby;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import ppalatjyo.server.domain.game.domain.Game;
+import ppalatjyo.server.domain.game.GameService;
 import ppalatjyo.server.domain.lobby.domain.Lobby;
 import ppalatjyo.server.domain.lobby.domain.LobbyOptions;
 import ppalatjyo.server.domain.lobby.dto.MessageToLobbyRequestDto;
@@ -15,19 +15,22 @@ import ppalatjyo.server.domain.quiz.repository.QuizRepository;
 import ppalatjyo.server.domain.user.UserRepository;
 import ppalatjyo.server.domain.user.domain.User;
 import ppalatjyo.server.domain.user.exception.UserNotFoundException;
-import ppalatjyo.server.domain.userlobby.UserLobbyService;
-import ppalatjyo.server.domain.userlobby.exception.LobbyIsFullException;
+import ppalatjyo.server.domain.userlobby.UserLobbyRepository;
 
+/**
+ * Lobby 도메인의 상태와 생명 주기를 관리합니다.
+ */
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class LobbyService {
 
     private final LobbyRepository lobbyRepository;
+    private final UserLobbyRepository userLobbyRepository;
     private final UserRepository userRepository;
     private final QuizRepository quizRepository;
     private final MessageService messageService;
-    private final UserLobbyService userLobbyService;
+    private final GameService gameService;
 
     public void createLobby(String name, long hostId, long quizId, LobbyOptions options) {
         User host = userRepository.findById(hostId).orElseThrow(UserNotFoundException::new);
@@ -47,6 +50,14 @@ public class LobbyService {
         lobby.delete();
     }
 
+    public void deleteIfEmpty(long lobbyId) {
+        if (userLobbyRepository.countByLobbyIdAndLeftAtIsNull(lobbyId) == 0) {
+            Lobby lobby = lobbyRepository.findById(lobbyId).orElseThrow(LobbyNotFoundException::new);
+            gameService.endGamesByLobbyId(lobbyId);
+            lobby.delete();
+        }
+    }
+
     public void changeHost(long lobbyId, long newHostId) {
         Lobby lobby = lobbyRepository.findById(lobbyId).orElseThrow(LobbyNotFoundException::new);
         User newHost = userRepository.findById(newHostId).orElseThrow(UserNotFoundException::new);
@@ -64,27 +75,5 @@ public class LobbyService {
     // MessageService로 위임
     public void sendMessageToLobby(MessageToLobbyRequestDto requestDto) {
         messageService.sendChatMessage(requestDto.getContent(), requestDto.getUserId(), requestDto.getLobbyId());
-    }
-
-    /**
-     * Lobby에 참가합니다. {@link UserLobbyService}로 위임합니다. 로비가 이미 가득 찬 경우 {@link LobbyIsFullException}을 던집니다.
-     */
-    public void joinLobby(long userId, long lobbyId) throws LobbyIsFullException {
-        userLobbyService.join(userId, lobbyId);
-    }
-
-    /**
-     * <p> User가 Lobby를 나갑니다. User가 나가고 더 이상 Lobby에 참가한 인원이 없으면 Lobby를 삭제합니다.
-     * <p> Lobby에서 실행되는 게임을 모두 종료합니다. (진행 중인 게임이 있는 경우 끝까지 진행되지 않게 하기 위함)
-     */
-    public void leaveLobby(long userId, long lobbyId) {
-        userLobbyService.leave(userId, lobbyId);
-
-        // 로비가 비었으면 게임 종료 후 삭제
-        Lobby lobby = lobbyRepository.findById(lobbyId).orElseThrow(LobbyNotFoundException::new);
-        if (lobby.isEmpty()) {
-            lobby.getGames().forEach(Game::end);
-            lobby.delete();
-        }
     }
 }

--- a/server/src/main/java/ppalatjyo/server/domain/lobby/LobbyService.java
+++ b/server/src/main/java/ppalatjyo/server/domain/lobby/LobbyService.java
@@ -33,7 +33,7 @@ public class LobbyService {
         User host = userRepository.findById(hostId).orElseThrow(UserNotFoundException::new);
         Quiz quiz = quizRepository.findById(quizId).orElseThrow(QuizNotFoundException::new);
 
-        Lobby lobby = Lobby.createLobby(name, host, quiz, options);
+        Lobby lobby = Lobby.create(name, host, quiz, options);
         lobbyRepository.save(lobby);
     }
 

--- a/server/src/main/java/ppalatjyo/server/domain/lobby/domain/Lobby.java
+++ b/server/src/main/java/ppalatjyo/server/domain/lobby/domain/Lobby.java
@@ -26,6 +26,7 @@ public class Lobby extends BaseEntity {
     private Long id;
 
     private String name;
+    private String password;
 
     @Embedded
     private LobbyOptions options;
@@ -47,9 +48,24 @@ public class Lobby extends BaseEntity {
     @OneToMany(mappedBy = "lobby")
     private List<Game> games;
 
-    public static Lobby createLobby(String name, User host, Quiz quiz, LobbyOptions options) {
+    public static Lobby create(String name, User host, Quiz quiz, LobbyOptions options) {
         Lobby lobby = Lobby.builder()
                 .name(name)
+                .host(host)
+                .quiz(quiz)
+                .userLobbies(new ArrayList<>())
+                .options(options)
+                .build();
+
+        UserLobby.join(host, lobby);
+
+        return lobby;
+    }
+
+    public static Lobby withPassword(String name, String password, User host, Quiz quiz, LobbyOptions options) {
+        Lobby lobby = Lobby.builder()
+                .name(name)
+                .password(password)
                 .host(host)
                 .quiz(quiz)
                 .userLobbies(new ArrayList<>())
@@ -90,10 +106,27 @@ public class Lobby extends BaseEntity {
     }
 
     /**
-     * Lobby에 참여한 유저가 남지 않았는지 확인하는 메서드.
+     * Lobby에 참여한 유저가 남지 않았는지 확인합니다.
      * @return Lobby가 비었으면 true | 아니면 false
      */
     public boolean isEmpty() {
         return userLobbies.stream().allMatch(UserLobby::isLeft);
+    }
+
+    /**
+     * 비밀번호가 설정된 채팅방인지 확인합니다.
+     * @return true이면 비밀번호가 있음
+     */
+    public boolean isProtected() {
+        return password != null && !password.isBlank();
+    }
+
+    /**
+     * 입력한 비밀번호가 맞는지 확인합니다.
+     * @param inputPassword 사용자가 입력한 비밀번호
+     * @return 비밀번호가 일치하면 true
+     */
+    public boolean isCorrectPassword(String inputPassword) {
+        return isProtected() && password.equals(inputPassword);
     }
 }

--- a/server/src/main/java/ppalatjyo/server/domain/userlobby/UserLobbyService.java
+++ b/server/src/main/java/ppalatjyo/server/domain/userlobby/UserLobbyService.java
@@ -4,17 +4,24 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import ppalatjyo.server.domain.game.domain.Game;
 import ppalatjyo.server.domain.lobby.LobbyRepository;
+import ppalatjyo.server.domain.lobby.LobbyService;
 import ppalatjyo.server.domain.lobby.domain.Lobby;
 import ppalatjyo.server.domain.lobby.exception.LobbyNotFoundException;
 import ppalatjyo.server.domain.user.UserRepository;
 import ppalatjyo.server.domain.user.domain.User;
 import ppalatjyo.server.domain.user.exception.UserNotFoundException;
+import ppalatjyo.server.domain.userlobby.dto.JoinLobbyRequestDto;
 import ppalatjyo.server.domain.userlobby.event.UserJoinedLobbyEvent;
 import ppalatjyo.server.domain.userlobby.event.UserLeftLobbyEvent;
 import ppalatjyo.server.domain.userlobby.exception.LobbyIsFullException;
 import ppalatjyo.server.domain.userlobby.exception.UserLobbyNotFoundException;
+import ppalatjyo.server.domain.userlobby.exception.WrongLobbyPasswordException;
 
+/**
+ * UserLobby 도메인의 상태와 생명 주기를 관리합니다.
+ */
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -24,13 +31,26 @@ public class UserLobbyService {
     private final LobbyRepository lobbyRepository;
     private final UserLobbyRepository userLobbyRepository;
     private final ApplicationEventPublisher applicationEventPublisher;
+    private final LobbyService lobbyService;
 
     /**
-     * Lobby에 User가 참가합니다. Lobby가 이미 가득찬 경우 {@link LobbyIsFullException} 예외를 반환합니다.
+     * Lobby에 User가 참가합니다.
+     * <p>비밀번호가 설정된 Lobby에 제공된 비밀번호가 맞지 않는 경우 {@link WrongLobbyPasswordException}을 던집니다.
+     * <p>Lobby가 이미 가득찬 경우 {@link LobbyIsFullException}을 던집니다.
      */
-    public void join(Long userId, Long lobbyId) throws LobbyIsFullException {
+    public void join(JoinLobbyRequestDto requestDto) throws LobbyIsFullException, WrongLobbyPasswordException {
+        long userId = requestDto.getUserId();
+        long lobbyId = requestDto.getLobbyId();
+        String password = requestDto.getPassword();
+
         User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
         Lobby lobby = lobbyRepository.findById(lobbyId).orElseThrow(LobbyNotFoundException::new);
+
+        if (lobby.isProtected()) {
+            if (password == null || !lobby.isCorrectPassword(password)) {
+                throw new WrongLobbyPasswordException();
+            }
+        }
 
         boolean alreadyJoined = userLobbyRepository.existsByUserIdAndLobbyIdAndLeftAtIsNull(userId, lobbyId);
         if (alreadyJoined) {
@@ -49,9 +69,17 @@ public class UserLobbyService {
         applicationEventPublisher.publishEvent(new UserJoinedLobbyEvent(userId, lobbyId));
     }
 
+    /**
+     * <p> User가 Lobby를 나갑니다. User가 나가고 더 이상 Lobby에 참가한 인원이 없으면 Lobby를 삭제합니다.
+     * <p> Lobby에서 실행되는 게임을 모두 종료합니다. (진행 중인 게임이 있는 경우 끝까지 진행되지 않게 하기 위함)
+     */
     public void leave(Long userId, Long lobbyId) {
         UserLobby userLobby = userLobbyRepository.findByUserIdAndLobbyId(userId, lobbyId).orElseThrow(UserLobbyNotFoundException::new);
         leave(userLobby);
+        userLobbyRepository.flush(); // 삭제 반영을 위해 flush() 합니다.
+
+        // 로비가 비었으면 게임 종료 후 삭제
+        lobbyService.deleteIfEmpty(lobbyId);
     }
 
     public void leaveAllLobbies(Long userId) {

--- a/server/src/main/java/ppalatjyo/server/domain/userlobby/dto/JoinLobbyRequestDto.java
+++ b/server/src/main/java/ppalatjyo/server/domain/userlobby/dto/JoinLobbyRequestDto.java
@@ -1,0 +1,17 @@
+package ppalatjyo.server.domain.userlobby.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+
+@Data
+@RequiredArgsConstructor
+@AllArgsConstructor
+public class JoinLobbyRequestDto {
+    @NotNull
+    private final Long userId;
+    @NotNull
+    private final Long lobbyId;
+    private String password;
+}

--- a/server/src/main/java/ppalatjyo/server/domain/userlobby/exception/WrongLobbyPasswordException.java
+++ b/server/src/main/java/ppalatjyo/server/domain/userlobby/exception/WrongLobbyPasswordException.java
@@ -1,0 +1,7 @@
+package ppalatjyo.server.domain.userlobby.exception;
+
+public class WrongLobbyPasswordException extends RuntimeException {
+    public WrongLobbyPasswordException() {
+        super("Wrong lobby password.");
+    }
+}

--- a/server/src/test/java/ppalatjyo/server/domain/game/GameServiceTest.java
+++ b/server/src/test/java/ppalatjyo/server/domain/game/GameServiceTest.java
@@ -7,8 +7,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import ppalatjyo.server.domain.game.GameRepository;
-import ppalatjyo.server.domain.game.GameService;
 import ppalatjyo.server.domain.game.domain.Game;
 import ppalatjyo.server.domain.game.dto.GameEventDto;
 import ppalatjyo.server.domain.game.dto.GameEventType;
@@ -62,7 +60,7 @@ class GameServiceTest {
         Quiz quiz = Quiz.createQuiz("quiz", host);
         Question question = Question.create(quiz, "question");
 
-        Lobby lobby = Lobby.createLobby("lobby", host, quiz, LobbyOptions.defaultOptions());
+        Lobby lobby = Lobby.create("lobby", host, quiz, LobbyOptions.defaultOptions());
         UserLobby.join(participant, lobby);
 
         when(lobbyRepository.findById(lobbyId)).thenReturn(Optional.of(lobby));
@@ -194,7 +192,7 @@ class GameServiceTest {
         Answer.createAnswer(question1, answer);
 
         Long lobbyId = 1L;
-        Lobby lobby = Lobby.createLobby("lobby", User.createGuest("host"), quiz, LobbyOptions.defaultOptions());
+        Lobby lobby = Lobby.create("lobby", User.createGuest("host"), quiz, LobbyOptions.defaultOptions());
 
         Long gameId = 1L;
         Game game = Game.start(lobby);
@@ -240,7 +238,7 @@ class GameServiceTest {
         Question question1 = Question.create(quiz, "question1");
         Answer.createAnswer(question1, answer);
 
-        Lobby lobby = Lobby.createLobby("lobby", User.createGuest("host"), quiz, LobbyOptions.defaultOptions());
+        Lobby lobby = Lobby.create("lobby", User.createGuest("host"), quiz, LobbyOptions.defaultOptions());
 
         Long gameId = 1L;
         Game game = Game.start(lobby);
@@ -270,7 +268,7 @@ class GameServiceTest {
     }
 
     private Game createGame(LobbyOptions options) {
-        Lobby lobby = Lobby.createLobby("lobby", User.createGuest("host"), createQuiz(), options);
+        Lobby lobby = Lobby.create("lobby", User.createGuest("host"), createQuiz(), options);
         return Game.start(lobby);
     }
 

--- a/server/src/test/java/ppalatjyo/server/domain/game/GameServiceTest.java
+++ b/server/src/test/java/ppalatjyo/server/domain/game/GameServiceTest.java
@@ -266,6 +266,21 @@ class GameServiceTest {
         assertThat(dto).isNull();
         verify(userGameRepository, never()).findByGameIdOrderByScoreDesc(any());
     }
+    
+    @Test
+    @DisplayName("lobbyId로 게임 전부 종료")
+    void endGamesByLobbyId() {
+        // given
+        Long lobbyId = 1L;
+        Game game = mock(Game.class);
+        when(gameRepository.findByLobbyId(lobbyId)).thenReturn(List.of(game));
+
+        // when
+        gameService.endGamesByLobbyId(lobbyId);
+        
+        // then
+        verify(game).end();
+    }
 
     private Game createGame(LobbyOptions options) {
         Lobby lobby = Lobby.create("lobby", User.createGuest("host"), createQuiz(), options);

--- a/server/src/test/java/ppalatjyo/server/domain/game/GameTest.java
+++ b/server/src/test/java/ppalatjyo/server/domain/game/GameTest.java
@@ -26,7 +26,7 @@ class GameTest {
         Question question = Question.create(quiz, "question1");
         Answer.createAnswer(question, "answer1");
 
-        Lobby lobby = Lobby.createLobby("lobby", user, quiz, LobbyOptions.defaultOptions());
+        Lobby lobby = Lobby.create("lobby", user, quiz, LobbyOptions.defaultOptions());
 
         // when
         Game game = Game.start(lobby);
@@ -52,7 +52,7 @@ class GameTest {
         Quiz quiz = Quiz.createQuiz("quiz", User.createMember("n", "e", "p"));
         Question.create(quiz,"question1");
 
-        Lobby lobby = Lobby.createLobby("lobby", user, quiz, LobbyOptions.defaultOptions());
+        Lobby lobby = Lobby.create("lobby", user, quiz, LobbyOptions.defaultOptions());
         Game game = Game.start(lobby);
 
         // when
@@ -72,7 +72,7 @@ class GameTest {
         Quiz quiz = Quiz.createQuiz("quiz", User.createMember("n", "e", "p"));
         Question.create(quiz,"question1");
 
-        Lobby lobby = Lobby.createLobby("lobby", user, quiz, LobbyOptions.defaultOptions());
+        Lobby lobby = Lobby.create("lobby", user, quiz, LobbyOptions.defaultOptions());
         Game game = Game.start(lobby);
         game.end();
 
@@ -89,7 +89,7 @@ class GameTest {
         Quiz quiz = Quiz.createQuiz("quiz", User.createMember("n", "e", "p"));
         Question.create(quiz, "question1");
         Question.create(quiz, "question2");
-        Lobby lobby = Lobby.createLobby("lobby", user, quiz, LobbyOptions.defaultOptions());
+        Lobby lobby = Lobby.create("lobby", user, quiz, LobbyOptions.defaultOptions());
 
         // when
         Game game = Game.start(lobby);
@@ -105,7 +105,7 @@ class GameTest {
         User user = User.createGuest("user");
         Quiz quiz = Quiz.createQuiz("quiz", User.createMember("n", "e", "p"));
         Question.create(quiz, "question1");
-        Lobby lobby = Lobby.createLobby("lobby", user, quiz, LobbyOptions.defaultOptions());
+        Lobby lobby = Lobby.create("lobby", user, quiz, LobbyOptions.defaultOptions());
 
         // when
         Game game = Game.start(lobby);
@@ -124,7 +124,7 @@ class GameTest {
         Question.create(quiz,"question1");
         Question.create(quiz, "question2");
 
-        Lobby lobby = Lobby.createLobby("lobby", user, quiz, LobbyOptions.defaultOptions());
+        Lobby lobby = Lobby.create("lobby", user, quiz, LobbyOptions.defaultOptions());
         Game game = Game.start(lobby);
 
         // when
@@ -143,7 +143,7 @@ class GameTest {
         Quiz quiz = Quiz.createQuiz("quiz", User.createMember("n", "e", "p"));
         Question.create(quiz,"question1");
 
-        Lobby lobby = Lobby.createLobby("lobby", user, quiz, LobbyOptions.defaultOptions());
+        Lobby lobby = Lobby.create("lobby", user, quiz, LobbyOptions.defaultOptions());
         Game game = Game.start(lobby);
 
         // when

--- a/server/src/test/java/ppalatjyo/server/domain/lobby/LobbyServiceTest.java
+++ b/server/src/test/java/ppalatjyo/server/domain/lobby/LobbyServiceTest.java
@@ -9,8 +9,6 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import ppalatjyo.server.domain.game.domain.Game;
-import ppalatjyo.server.domain.lobby.LobbyRepository;
-import ppalatjyo.server.domain.lobby.LobbyService;
 import ppalatjyo.server.domain.lobby.domain.Lobby;
 import ppalatjyo.server.domain.lobby.domain.LobbyOptions;
 import ppalatjyo.server.domain.lobby.dto.MessageToLobbyRequestDto;
@@ -50,7 +48,7 @@ class LobbyServiceTest {
 
     @Test
     @DisplayName("Lobby 생성")
-    void createLobby() {
+    void create() {
         // given
         String name = "lobby";
         User host = User.createGuest("host");
@@ -89,7 +87,7 @@ class LobbyServiceTest {
         User host = User.createGuest("host");
         Quiz quiz = Quiz.createQuiz("quiz", User.createMember("n", "e", "p"));
         LobbyOptions options = LobbyOptions.createOptions(10, 10, 10);
-        Lobby lobby = Lobby.createLobby(name, host, quiz, options);
+        Lobby lobby = Lobby.create(name, host, quiz, options);
 
         long lobbyId = 1L;
         when(lobbyRepository.findById(lobbyId)).thenReturn(Optional.of(lobby));
@@ -113,7 +111,7 @@ class LobbyServiceTest {
         User host = User.createGuest("host");
         Quiz quiz = Quiz.createQuiz("quiz", User.createMember("n", "e", "p"));
         LobbyOptions options = LobbyOptions.defaultOptions();
-        Lobby lobby = Lobby.createLobby(name, host, quiz, options);
+        Lobby lobby = Lobby.create(name, host, quiz, options);
 
         long lobbyId = 1L;
         when(lobbyRepository.findById(lobbyId)).thenReturn(Optional.of(lobby));
@@ -134,7 +132,7 @@ class LobbyServiceTest {
         User newHost = User.createGuest("newHost");
         Quiz quiz = Quiz.createQuiz("quiz", User.createMember("n", "e", "p"));
         LobbyOptions options = LobbyOptions.defaultOptions();
-        Lobby lobby = Lobby.createLobby(name, oldHost, quiz, options);
+        Lobby lobby = Lobby.create(name, oldHost, quiz, options);
 
         long lobbyId = 1L;
         long newHostId = 1L;
@@ -154,7 +152,7 @@ class LobbyServiceTest {
         // given
         Quiz oldQuiz = Quiz.createQuiz("oldQuiz", User.createMember("n", "e", "p"));
         Quiz newQuiz = Quiz.createQuiz("newQuiz", User.createMember("n", "e", "p"));
-        Lobby lobby = Lobby.createLobby("lobby", User.createGuest("host"), oldQuiz, LobbyOptions.defaultOptions());
+        Lobby lobby = Lobby.create("lobby", User.createGuest("host"), oldQuiz, LobbyOptions.defaultOptions());
 
         long newQuizId = 1L;
         long lobbyId = 1L;

--- a/server/src/test/java/ppalatjyo/server/domain/lobby/LobbyServiceTest.java
+++ b/server/src/test/java/ppalatjyo/server/domain/lobby/LobbyServiceTest.java
@@ -40,9 +40,6 @@ class LobbyServiceTest {
     @Mock
     private MessageService messageService;
 
-    @Mock
-    private UserLobbyService userLobbyService;
-
     @InjectMocks
     private LobbyService lobbyService;
 
@@ -180,63 +177,5 @@ class LobbyServiceTest {
 
         // then
         verify(messageService, times(1)).sendChatMessage(content, userId, lobbyId);
-    }
-
-    @Test
-    @DisplayName("채팅방 참가 -> UserLobbyService로 위임")
-    void joinLobby() {
-        // given
-        long userId = 1L;
-        long lobbyId = 1L;
-
-        // when
-        lobbyService.joinLobby(userId, lobbyId);
-
-        // then
-        verify(userLobbyService, times(1)).join(userId, lobbyId);
-    }
-
-    @Test
-    @DisplayName("채팅방 나가기 -> UserLobbyService로 위임")
-    void leaveLobby() {
-        // given
-        long userId = 1L;
-        long lobbyId = 1L;
-
-        Lobby lobby = Mockito.mock(Lobby.class);
-        when(lobbyRepository.findById(lobbyId)).thenReturn(Optional.of(lobby));
-        when(lobby.isEmpty()).thenReturn(false);
-
-        when(lobbyRepository.findById(lobbyId)).thenReturn(Optional.of(lobby));
-
-        // when
-        lobbyService.leaveLobby(userId, lobbyId);
-
-        // then
-        verify(userLobbyService).leave(userId, lobbyId);
-        verify(lobby, never()).delete();
-    }
-
-    @Test
-    @DisplayName("채팅방 나가기 -> 남은 사람이 없으면 채팅방 삭제")
-    void leaveLobbyDeleteWhenEmpty() {
-        // given
-        long userId = 1L;
-        long lobbyId = 1L;
-
-        Lobby lobby = Mockito.mock(Lobby.class);
-        Game game = Mockito.mock(Game.class);
-        when(lobbyRepository.findById(lobbyId)).thenReturn(Optional.of(lobby));
-        when(lobby.isEmpty()).thenReturn(true);
-        when(lobby.getGames()).thenReturn(List.of(game));
-
-        // when
-        lobbyService.leaveLobby(userId, lobbyId);
-
-        // then
-        verify(userLobbyService).leave(userId, lobbyId);
-        verify(lobbyRepository).findById(lobbyId);
-        verify(game).end();
-        verify(lobby).delete();
     }
 }

--- a/server/src/test/java/ppalatjyo/server/domain/lobby/LobbyTest.java
+++ b/server/src/test/java/ppalatjyo/server/domain/lobby/LobbyTest.java
@@ -16,7 +16,7 @@ class LobbyTest {
 
     @Test
     @DisplayName("Lobby 생성")
-    void createLobby() {
+    void create() {
         // given
         String name = "name";
         User host = User.createGuest("user");
@@ -28,7 +28,7 @@ class LobbyTest {
         LobbyOptions options = LobbyOptions.createOptions(maxUsers, minPerGame, secPerQuestion);
 
         // when
-        Lobby lobby = Lobby.createLobby(name, host, quiz, options);
+        Lobby lobby = Lobby.create(name, host, quiz, options);
 
         // then
         assertThat(lobby.getName()).isEqualTo(name);
@@ -41,12 +41,43 @@ class LobbyTest {
     }
 
     @Test
+    @DisplayName("Lobby 생성 - 비밀번호")
+    void withPassword() {
+        // given
+        String name = "name";
+        String password = "1234";
+        User host = User.createGuest("user");
+        Quiz quiz = Quiz.createQuiz("quiz", User.createMember("n", "e", "p"));
+        int maxUsers = 10;
+        int minPerGame = 10;
+        int secPerQuestion = 60;
+
+        LobbyOptions options = LobbyOptions.createOptions(maxUsers, minPerGame, secPerQuestion);
+
+        // when
+        Lobby lobby = Lobby.withPassword(name, password, host, quiz, options);
+
+        // then
+        assertThat(lobby.getName()).isEqualTo(name);
+        assertThat(lobby.getHost()).isEqualTo(host);
+        assertThat(lobby.getQuiz()).isEqualTo(quiz);
+        assertThat(lobby.getOptions().getMaxUsers()).isEqualTo(maxUsers);
+        assertThat(lobby.getOptions().getMinPerGame()).isEqualTo(minPerGame);
+        assertThat(lobby.getOptions().getSecPerQuestion()).isEqualTo(secPerQuestion);
+        assertThat(lobby.getUserLobbies().size()).isEqualTo(1);
+
+        assertThat(lobby.getPassword()).isEqualTo(password);
+        assertThat(lobby.isProtected()).isTrue();
+        assertThat(lobby.isCorrectPassword(password)).isTrue();
+    }
+
+    @Test
     @DisplayName("Lobby 이름 변경")
     void changeName() {
         // given
         String oldName = "oldName";
         String newName = "newName";
-        Lobby lobby = Lobby.createLobby(oldName, User.createGuest("host"), Quiz.createQuiz("quiz", User.createMember("n", "e", "p")), LobbyOptions.defaultOptions());
+        Lobby lobby = Lobby.create(oldName, User.createGuest("host"), Quiz.createQuiz("quiz", User.createMember("n", "e", "p")), LobbyOptions.defaultOptions());
 
         // when
         lobby.changeName(newName);
@@ -59,7 +90,7 @@ class LobbyTest {
     @DisplayName("Lobby 삭제")
     void deleteLobby() {
         // given
-        Lobby lobby = Lobby.createLobby("lobby", User.createGuest("host"), Quiz.createQuiz("quiz", User.createMember("n", "e", "p")), LobbyOptions.defaultOptions());
+        Lobby lobby = Lobby.create("lobby", User.createGuest("host"), Quiz.createQuiz("quiz", User.createMember("n", "e", "p")), LobbyOptions.defaultOptions());
 
         // when
         lobby.delete();
@@ -73,7 +104,7 @@ class LobbyTest {
     @DisplayName("삭제된 Lobby는 삭제할 수 없음")
     void lobbyAlreadyDeleted() {
         // given
-        Lobby lobby = Lobby.createLobby("lobby", User.createGuest("host"), Quiz.createQuiz("quiz", User.createMember("n", "e", "p")), LobbyOptions.defaultOptions());
+        Lobby lobby = Lobby.create("lobby", User.createGuest("host"), Quiz.createQuiz("quiz", User.createMember("n", "e", "p")), LobbyOptions.defaultOptions());
         lobby.delete();
 
         // when
@@ -88,7 +119,7 @@ class LobbyTest {
         User oldHost = User.createGuest("oldHost");
         User newHost = User.createGuest("newHost");
 
-        Lobby lobby = Lobby.createLobby("lobby", oldHost, Quiz.createQuiz("quiz", User.createMember("n", "e", "p")), LobbyOptions.defaultOptions());
+        Lobby lobby = Lobby.create("lobby", oldHost, Quiz.createQuiz("quiz", User.createMember("n", "e", "p")), LobbyOptions.defaultOptions());
 
         // when
         lobby.changeHost(newHost);
@@ -102,7 +133,7 @@ class LobbyTest {
     void changeOptions() {
         // given
         LobbyOptions options = LobbyOptions.createOptions(10, 10, 10);
-        Lobby lobby = Lobby.createLobby("lobby", User.createGuest("host"), Quiz.createQuiz("quiz", User.createMember("n", "e", "p")), options);
+        Lobby lobby = Lobby.create("lobby", User.createGuest("host"), Quiz.createQuiz("quiz", User.createMember("n", "e", "p")), options);
         LobbyOptions newOptions = LobbyOptions.createOptions(20, 20, 20);
 
         // when
@@ -119,7 +150,7 @@ class LobbyTest {
     void changeQuiz() {
         // given
         Quiz oldQuiz = Quiz.createQuiz("oldQuiz", User.createMember("n", "e", "p"));
-        Lobby lobby = Lobby.createLobby("lobby", User.createGuest("host"), oldQuiz, LobbyOptions.defaultOptions());
+        Lobby lobby = Lobby.create("lobby", User.createGuest("host"), oldQuiz, LobbyOptions.defaultOptions());
 
         Quiz newQuiz = Quiz.createQuiz("newQuiz", User.createMember("n", "e", "p"));
 
@@ -136,7 +167,7 @@ class LobbyTest {
         // given
         Quiz quiz = Quiz.createQuiz("oldQuiz", User.createMember("n", "e", "p"));
         User user = User.createGuest("host");
-        Lobby lobby = Lobby.createLobby("lobby", user, quiz, LobbyOptions.defaultOptions());
+        Lobby lobby = Lobby.create("lobby", user, quiz, LobbyOptions.defaultOptions());
 
         lobby.getUserLobbies().forEach(UserLobby::leave);
 
@@ -153,7 +184,7 @@ class LobbyTest {
         // given
         Quiz quiz = Quiz.createQuiz("oldQuiz", User.createMember("n", "e", "p"));
         User user = User.createGuest("host");
-        Lobby lobby = Lobby.createLobby("lobby", user, quiz, LobbyOptions.defaultOptions());
+        Lobby lobby = Lobby.create("lobby", user, quiz, LobbyOptions.defaultOptions());
 
         // when
         boolean isEmpty = lobby.isEmpty();

--- a/server/src/test/java/ppalatjyo/server/domain/message/MessageServiceTest.java
+++ b/server/src/test/java/ppalatjyo/server/domain/message/MessageServiceTest.java
@@ -7,9 +7,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import ppalatjyo.server.domain.message.MessageRepository;
-import ppalatjyo.server.domain.message.MessageResponseDto;
-import ppalatjyo.server.domain.message.MessageService;
 import ppalatjyo.server.global.websocket.aop.SendAfterCommitDto;
 import ppalatjyo.server.domain.lobby.LobbyRepository;
 import ppalatjyo.server.domain.lobby.domain.Lobby;
@@ -43,7 +40,7 @@ class MessageServiceTest {
         String content = "content";
 
         User user = User.createGuest("user");
-        Lobby lobby = Lobby.createLobby("lobby", user, null, null);
+        Lobby lobby = Lobby.create("lobby", user, null, null);
 
         when(userRepository.findById(anyLong())).thenReturn(Optional.of(user));
         when(lobbyRepository.findById(anyLong())).thenReturn(Optional.of(lobby));
@@ -71,7 +68,7 @@ class MessageServiceTest {
         // given
         String content = "content";
 
-        Lobby lobby = Lobby.createLobby("lobby", User.createGuest(""), null, null);
+        Lobby lobby = Lobby.create("lobby", User.createGuest(""), null, null);
 
         when(lobbyRepository.findById(anyLong())).thenReturn(Optional.of(lobby));
 

--- a/server/src/test/java/ppalatjyo/server/domain/message/MessageTest.java
+++ b/server/src/test/java/ppalatjyo/server/domain/message/MessageTest.java
@@ -22,7 +22,7 @@ class MessageTest {
         // given
         String content = "content";
         User user = User.createGuest("user");
-        Lobby lobby = Lobby.createLobby("lobby", user, null, LobbyOptions.defaultOptions());
+        Lobby lobby = Lobby.create("lobby", user, null, LobbyOptions.defaultOptions());
 
         // when
         Message message = Message.chatMessage(content, user, lobby);
@@ -39,7 +39,7 @@ class MessageTest {
         // given
         String content = "content";
         User user = User.createGuest("user");
-        Lobby lobby = Lobby.createLobby("lobby", user, getQuiz(), LobbyOptions.defaultOptions());
+        Lobby lobby = Lobby.create("lobby", user, getQuiz(), LobbyOptions.defaultOptions());
         Game game = Game.start(lobby);
 
         // when
@@ -58,7 +58,7 @@ class MessageTest {
         // given
         String content = "content";
         User user = User.createGuest("user");
-        Lobby lobby = Lobby.createLobby("lobby", user, getQuiz(), LobbyOptions.defaultOptions());
+        Lobby lobby = Lobby.create("lobby", user, getQuiz(), LobbyOptions.defaultOptions());
 
         // when
         Message message = Message.systemMessage(content, lobby);

--- a/server/src/test/java/ppalatjyo/server/domain/usergame/UserGameServiceTest.java
+++ b/server/src/test/java/ppalatjyo/server/domain/usergame/UserGameServiceTest.java
@@ -12,9 +12,6 @@ import ppalatjyo.server.domain.lobby.domain.LobbyOptions;
 import ppalatjyo.server.domain.quiz.domain.Question;
 import ppalatjyo.server.domain.quiz.domain.Quiz;
 import ppalatjyo.server.domain.user.domain.User;
-import ppalatjyo.server.domain.usergame.UserGame;
-import ppalatjyo.server.domain.usergame.UserGameRepository;
-import ppalatjyo.server.domain.usergame.UserGameService;
 
 import java.util.Optional;
 
@@ -36,7 +33,7 @@ class UserGameServiceTest {
         // given
         User user = User.createGuest("user");
         Quiz quiz = Quiz.createQuiz("quiz", User.createMember("m", "email", "password"));
-        Lobby lobby = Lobby.createLobby(
+        Lobby lobby = Lobby.create(
                 "lobby",
                 user,
                 quiz,

--- a/server/src/test/java/ppalatjyo/server/domain/usergame/UserGameTest.java
+++ b/server/src/test/java/ppalatjyo/server/domain/usergame/UserGameTest.java
@@ -9,7 +9,6 @@ import ppalatjyo.server.domain.quiz.domain.Answer;
 import ppalatjyo.server.domain.quiz.domain.Question;
 import ppalatjyo.server.domain.quiz.domain.Quiz;
 import ppalatjyo.server.domain.user.domain.User;
-import ppalatjyo.server.domain.usergame.UserGame;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -20,7 +19,7 @@ class UserGameTest {
     void join() {
         // given
         User user = User.createGuest("guest");
-        Lobby lobby = Lobby.createLobby("lobby", user, getQuiz(), LobbyOptions.defaultOptions());
+        Lobby lobby = Lobby.create("lobby", user, getQuiz(), LobbyOptions.defaultOptions());
         Game game = Game.start(lobby);
 
         // when
@@ -37,7 +36,7 @@ class UserGameTest {
     void increaseScoreBy() {
         // given
         User user = User.createGuest("guest");
-        Lobby lobby = Lobby.createLobby("lobby", user, getQuiz(), LobbyOptions.defaultOptions());
+        Lobby lobby = Lobby.create("lobby", user, getQuiz(), LobbyOptions.defaultOptions());
         Game game = Game.start(lobby);
         UserGame userGame = UserGame.join(user, game);
 

--- a/server/src/test/java/ppalatjyo/server/domain/userlobby/UserLobbyServiceTest.java
+++ b/server/src/test/java/ppalatjyo/server/domain/userlobby/UserLobbyServiceTest.java
@@ -15,9 +15,6 @@ import ppalatjyo.server.domain.lobby.domain.LobbyOptions;
 import ppalatjyo.server.domain.quiz.domain.Quiz;
 import ppalatjyo.server.domain.user.UserRepository;
 import ppalatjyo.server.domain.user.domain.User;
-import ppalatjyo.server.domain.userlobby.UserLobby;
-import ppalatjyo.server.domain.userlobby.UserLobbyRepository;
-import ppalatjyo.server.domain.userlobby.UserLobbyService;
 import ppalatjyo.server.domain.userlobby.event.UserLeftLobbyEvent;
 import ppalatjyo.server.domain.userlobby.exception.LobbyIsFullException;
 
@@ -54,7 +51,7 @@ class UserLobbyServiceTest {
         Long lobbyId = 1L;
 
         User host = User.createMember("host", "email", "provider");
-        Lobby lobby = Lobby.createLobby("lobby", host, Quiz.createQuiz("quiz", host), LobbyOptions.defaultOptions());
+        Lobby lobby = Lobby.create("lobby", host, Quiz.createQuiz("quiz", host), LobbyOptions.defaultOptions());
         User user = User.createGuest("user");
 
         when(userRepository.findById(userId)).thenReturn(Optional.of(user));
@@ -87,7 +84,7 @@ class UserLobbyServiceTest {
         LobbyOptions options = LobbyOptions.createOptions(maxUsers, 10, 10);
 
         User host = User.createMember("host", "email", "provider");
-        Lobby lobby = Lobby.createLobby("lobby", host, Quiz.createQuiz("quiz", host), options);
+        Lobby lobby = Lobby.create("lobby", host, Quiz.createQuiz("quiz", host), options);
         User user = User.createGuest("user");
 
         when(userRepository.findById(userId)).thenReturn(Optional.of(user));
@@ -109,7 +106,7 @@ class UserLobbyServiceTest {
         Long lobbyId = 1L;
 
         User host = User.createMember("host", "email", "provider");
-        Lobby lobby = Lobby.createLobby("lobby", host, Quiz.createQuiz("quiz", host), LobbyOptions.defaultOptions());
+        Lobby lobby = Lobby.create("lobby", host, Quiz.createQuiz("quiz", host), LobbyOptions.defaultOptions());
         User user = User.createGuest("user");
 
         UserLobby userLobby = UserLobby.join(user, lobby);

--- a/server/src/test/java/ppalatjyo/server/domain/userlobby/UserLobbyTest.java
+++ b/server/src/test/java/ppalatjyo/server/domain/userlobby/UserLobbyTest.java
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.Test;
 import ppalatjyo.server.domain.lobby.domain.Lobby;
 import ppalatjyo.server.domain.lobby.domain.LobbyOptions;
 import ppalatjyo.server.domain.user.domain.User;
-import ppalatjyo.server.domain.userlobby.UserLobby;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -16,7 +15,7 @@ class UserLobbyTest {
     void join() {
         // given
         User user = User.createGuest("user");
-        Lobby lobby = Lobby.createLobby("lobby", user, null, LobbyOptions.defaultOptions());
+        Lobby lobby = Lobby.create("lobby", user, null, LobbyOptions.defaultOptions());
 
         // when
         UserLobby userLobby = UserLobby.join(user, lobby);
@@ -33,7 +32,7 @@ class UserLobbyTest {
     void leave() {
         // given
         User user = User.createGuest("user");
-        Lobby lobby = Lobby.createLobby("lobby", user, null, LobbyOptions.defaultOptions());
+        Lobby lobby = Lobby.create("lobby", user, null, LobbyOptions.defaultOptions());
         UserLobby userLobby = UserLobby.join(user, lobby);
 
         // when


### PR DESCRIPTION
## 관련 이슈

- #108 

## 변경 사항

- [Lobby 도메인에 password 필드 추가 및 메서드 추가](https://github.com/gyehyun-bak/ppalatjyo/commit/61e99dcbf181511586283311ee4291ecdf97c736)하였습니다.
- 로비 생성 시 비밀번호를 지정할 수 있는 `withPassword()` 펙토리 메서드를 추가하였습니다.
- [UserLobbyService의 join(), leave() 수정](https://github.com/gyehyun-bak/ppalatjyo/commit/a418d1469d36391b62369e7047af8784b3132b04)하였습니다.
  - 로비 참가 시, 기존 참가 여부와 비밀번호 설정 여부를 확인하고, 제공된 비밀번호를 확인합니다. -> 틀리면 예외를 던집니다.
  - 로비 퇴장 시, 빈 채팅방은 삭제하도록 `LobbyService` 의 `deleteIfEmpty()`를 호출합니다.
- [LobbyService에서 join(), leave() 제거 + deleteIfEmpty() 추가 + 테스트 수정](https://github.com/gyehyun-bak/ppalatjyo/commit/2fae00b6470ba27b448191265e690673244b74f6)하였습니다.
- [GameService에서 endGamesByLobbyId() 추가 + 테스트 추가](https://github.com/gyehyun-bak/ppalatjyo/commit/9b9165dad7f33d74cbd8d47d9235969a26b88483)하였습니다.
- 관련 테스트를 수정하였습니다.

## 고려 사항 및 주의 사항 (선택)

- 나중에 테스트 커버리지 확인이 필요합니다.

## 추가 정보 (선택)
