### PR TITLE
[FEATURE #115]: 게임 중에는 로비에 참여할 수 없게 구현

### DIFF
--- a/server/src/main/java/ppalatjyo/server/domain/game/domain/Game.java
+++ b/server/src/main/java/ppalatjyo/server/domain/game/domain/Game.java
@@ -4,6 +4,7 @@ package ppalatjyo.server.domain.game.domain;
 import jakarta.persistence.*;
 import lombok.*;
 import ppalatjyo.server.domain.game.exception.GameAlreadyEndedException;
+import ppalatjyo.server.domain.lobby.domain.LobbyStatus;
 import ppalatjyo.server.global.audit.BaseEntity;
 import ppalatjyo.server.domain.lobby.domain.Lobby;
 import ppalatjyo.server.domain.quiz.domain.Question;
@@ -50,6 +51,8 @@ public class Game extends BaseEntity {
     private GameOptions options;
 
     public static Game start(Lobby lobby) {
+        lobby.changeStatus(LobbyStatus.IN_GAME);
+
         Game game = Game.builder()
                 .lobby(lobby)
                 .quiz(lobby.getQuiz())
@@ -75,6 +78,7 @@ public class Game extends BaseEntity {
         }
 
         endedAt = LocalDateTime.now();
+        lobby.changeStatus(LobbyStatus.WAITING);
     }
 
     public boolean isEnded() {

--- a/server/src/main/java/ppalatjyo/server/domain/lobby/domain/Lobby.java
+++ b/server/src/main/java/ppalatjyo/server/domain/lobby/domain/Lobby.java
@@ -137,4 +137,8 @@ public class Lobby extends BaseEntity {
     public void changeStatus(LobbyStatus status) {
         this.status = status;
     }
+
+    public boolean isInGame() {
+        return status == LobbyStatus.IN_GAME;
+    }
 }

--- a/server/src/main/java/ppalatjyo/server/domain/lobby/domain/Lobby.java
+++ b/server/src/main/java/ppalatjyo/server/domain/lobby/domain/Lobby.java
@@ -28,6 +28,10 @@ public class Lobby extends BaseEntity {
     private String name;
     private String password;
 
+    @Builder.Default
+    @Enumerated(EnumType.STRING)
+    private LobbyStatus status = LobbyStatus.WAITING;
+
     @Embedded
     private LobbyOptions options;
 

--- a/server/src/main/java/ppalatjyo/server/domain/lobby/domain/Lobby.java
+++ b/server/src/main/java/ppalatjyo/server/domain/lobby/domain/Lobby.java
@@ -133,4 +133,8 @@ public class Lobby extends BaseEntity {
     public boolean isCorrectPassword(String inputPassword) {
         return isProtected() && password.equals(inputPassword);
     }
+
+    public void changeStatus(LobbyStatus status) {
+        this.status = status;
+    }
 }

--- a/server/src/main/java/ppalatjyo/server/domain/lobby/domain/LobbyStatus.java
+++ b/server/src/main/java/ppalatjyo/server/domain/lobby/domain/LobbyStatus.java
@@ -1,0 +1,5 @@
+package ppalatjyo.server.domain.lobby.domain;
+
+public enum LobbyStatus {
+    WAITING, IN_GAME
+}

--- a/server/src/main/java/ppalatjyo/server/domain/userlobby/exception/LobbyIsInGameException.java
+++ b/server/src/main/java/ppalatjyo/server/domain/userlobby/exception/LobbyIsInGameException.java
@@ -1,0 +1,7 @@
+package ppalatjyo.server.domain.userlobby.exception;
+
+public class LobbyIsInGameException extends RuntimeException{
+    public LobbyIsInGameException() {
+        super("Lobby is in game.");
+    }
+}

--- a/server/src/test/java/ppalatjyo/server/domain/game/GameTest.java
+++ b/server/src/test/java/ppalatjyo/server/domain/game/GameTest.java
@@ -6,6 +6,7 @@ import ppalatjyo.server.domain.game.domain.Game;
 import ppalatjyo.server.domain.game.exception.GameAlreadyEndedException;
 import ppalatjyo.server.domain.lobby.domain.Lobby;
 import ppalatjyo.server.domain.lobby.domain.LobbyOptions;
+import ppalatjyo.server.domain.lobby.domain.LobbyStatus;
 import ppalatjyo.server.domain.quiz.domain.Answer;
 import ppalatjyo.server.domain.quiz.domain.Question;
 import ppalatjyo.server.domain.quiz.domain.Quiz;
@@ -41,6 +42,8 @@ class GameTest {
         assertThat(game.isEnded()).isFalse();
 
         assertThat(game.getUserGames().size()).isEqualTo(1);
+
+        assertThat(lobby.getStatus()).isEqualTo(LobbyStatus.IN_GAME);
     }
 
     @Test
@@ -61,6 +64,7 @@ class GameTest {
         // then
         assertThat(game.isEnded()).isTrue();
         assertThat(game.getEndedAt()).isNotNull();
+        assertThat(lobby.getStatus()).isEqualTo(LobbyStatus.WAITING);
     }
 
     @Test

--- a/server/src/test/java/ppalatjyo/server/domain/lobby/LobbyTest.java
+++ b/server/src/test/java/ppalatjyo/server/domain/lobby/LobbyTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import ppalatjyo.server.domain.lobby.domain.Lobby;
 import ppalatjyo.server.domain.lobby.domain.LobbyOptions;
+import ppalatjyo.server.domain.lobby.domain.LobbyStatus;
 import ppalatjyo.server.domain.lobby.exception.LobbyAlreadyDeletedException;
 import ppalatjyo.server.domain.quiz.domain.Quiz;
 import ppalatjyo.server.domain.user.domain.User;
@@ -34,6 +35,7 @@ class LobbyTest {
         assertThat(lobby.getName()).isEqualTo(name);
         assertThat(lobby.getHost()).isEqualTo(host);
         assertThat(lobby.getQuiz()).isEqualTo(quiz);
+        assertThat(lobby.getStatus()).isEqualTo(LobbyStatus.WAITING);
         assertThat(lobby.getOptions().getMaxUsers()).isEqualTo(maxUsers);
         assertThat(lobby.getOptions().getMinPerGame()).isEqualTo(minPerGame);
         assertThat(lobby.getOptions().getSecPerQuestion()).isEqualTo(secPerQuestion);
@@ -61,6 +63,7 @@ class LobbyTest {
         assertThat(lobby.getName()).isEqualTo(name);
         assertThat(lobby.getHost()).isEqualTo(host);
         assertThat(lobby.getQuiz()).isEqualTo(quiz);
+        assertThat(lobby.getStatus()).isEqualTo(LobbyStatus.WAITING);
         assertThat(lobby.getOptions().getMaxUsers()).isEqualTo(maxUsers);
         assertThat(lobby.getOptions().getMinPerGame()).isEqualTo(minPerGame);
         assertThat(lobby.getOptions().getSecPerQuestion()).isEqualTo(secPerQuestion);


### PR DESCRIPTION
## 관련 이슈

- #115 

## 변경 사항

- `Lobby` 도메인에 `LobbyStatus`를 추가하였습니다. `WAITING`과 `IN_GAME`이 있습니다.
- `Game` 도메인에서 `Lobby` 객체를 통해 `start()`하면 `Lobby`의 status를 `IN_GAME`으로 변경합니다.
- `Game` 에서 `delete()`를 하면 내부 `lobby`의 status를 `WAITING`으로 변경합니다.
- `UserLobbyService.join()` 에서 Lobby가 게임 중이면 `LobbyIsInGameException`을 던집니다.
- 관련 테스트를 추가/수정하였습니다.

## 고려 사항 및 주의 사항 (선택)

- `UserLobbyService.join()`가 매우 커짐 이슈...

## 추가 정보 (선택)
