### PR TITLE
[FEATURE #124]: Quiz 도메인에 설명과 공개 여부 추가

### DIFF
--- a/server/src/main/java/ppalatjyo/server/domain/quiz/AnswerService.java
+++ b/server/src/main/java/ppalatjyo/server/domain/quiz/AnswerService.java
@@ -5,8 +5,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import ppalatjyo.server.domain.quiz.domain.Answer;
 import ppalatjyo.server.domain.quiz.domain.Question;
-import ppalatjyo.server.domain.quiz.dto.AnswerCreateRequestDto;
-import ppalatjyo.server.domain.quiz.dto.AnswerUpdateRequestDto;
+import ppalatjyo.server.domain.quiz.dto.CreateAnswerRequestDto;
+import ppalatjyo.server.domain.quiz.dto.UpdateAnswerRequestDto;
 import ppalatjyo.server.domain.quiz.exception.AnswerNotFoundException;
 import ppalatjyo.server.domain.quiz.exception.QuestionNotFoundException;
 import ppalatjyo.server.domain.quiz.repository.AnswerRepository;
@@ -20,13 +20,13 @@ public class AnswerService {
     private final AnswerRepository answerRepository;
     private final QuestionRepository questionRepository;
 
-    public void create(AnswerCreateRequestDto requestDto) {
+    public void create(CreateAnswerRequestDto requestDto) {
         Question question = questionRepository.findById(requestDto.getQuestionId()).orElseThrow(QuestionNotFoundException::new);
         Answer answer = Answer.createAnswer(question, requestDto.getContent());
         answerRepository.save(answer);
     }
 
-    public void update(AnswerUpdateRequestDto requestDto) {
+    public void update(UpdateAnswerRequestDto requestDto) {
         Answer answer = answerRepository.findById(requestDto.getAnswerId()).orElseThrow(AnswerNotFoundException::new);
         answer.changeContent(requestDto.getContent());
     }

--- a/server/src/main/java/ppalatjyo/server/domain/quiz/QuestionService.java
+++ b/server/src/main/java/ppalatjyo/server/domain/quiz/QuestionService.java
@@ -5,8 +5,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import ppalatjyo.server.domain.quiz.domain.Question;
 import ppalatjyo.server.domain.quiz.domain.Quiz;
-import ppalatjyo.server.domain.quiz.dto.QuestionCreateRequestDto;
-import ppalatjyo.server.domain.quiz.dto.QuestionUpdateRequestDto;
+import ppalatjyo.server.domain.quiz.dto.CreateQuestionRequestDto;
+import ppalatjyo.server.domain.quiz.dto.UpdateQuestionRequestDto;
 import ppalatjyo.server.domain.quiz.exception.QuestionNotFoundException;
 import ppalatjyo.server.domain.quiz.exception.QuizNotFoundException;
 import ppalatjyo.server.domain.quiz.repository.QuestionRepository;
@@ -20,13 +20,13 @@ public class QuestionService {
     private final QuestionRepository questionRepository;
     private final QuizRepository quizRepository;
 
-    public void create(QuestionCreateRequestDto requestDto) {
+    public void create(CreateQuestionRequestDto requestDto) {
         Quiz quiz = quizRepository.findById(requestDto.getQuizId()).orElseThrow(QuizNotFoundException::new);
         Question question = Question.create(quiz, requestDto.getContent());
         questionRepository.save(question);
     }
 
-    public void updateQuestion(QuestionUpdateRequestDto requestDto) {
+    public void updateQuestion(UpdateQuestionRequestDto requestDto) {
         Question question = questionRepository.findById(requestDto.getQuestionId()).orElseThrow(QuestionNotFoundException::new);
 
         String content = requestDto.getContent();

--- a/server/src/main/java/ppalatjyo/server/domain/quiz/QuizService.java
+++ b/server/src/main/java/ppalatjyo/server/domain/quiz/QuizService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import ppalatjyo.server.domain.quiz.domain.Quiz;
+import ppalatjyo.server.domain.quiz.dto.CreateQuizRequestDto;
 import ppalatjyo.server.domain.quiz.exception.QuizNotFoundException;
 import ppalatjyo.server.domain.quiz.repository.QuizRepository;
 import ppalatjyo.server.domain.user.UserRepository;
@@ -18,9 +19,9 @@ public class QuizService {
     private final QuizRepository quizRepository;
     private final UserRepository userRepository;
 
-    public void create(String title, Long userId) {
-        User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
-        Quiz quiz = Quiz.createQuiz(title, user);
+    public void create(CreateQuizRequestDto requestDto) {
+        User user = userRepository.findById(requestDto.getUserId()).orElseThrow(UserNotFoundException::new);
+        Quiz quiz = Quiz.createQuiz(requestDto.getTitle(), user, requestDto.getDescription(), requestDto.getVisibility());
         quizRepository.save(quiz);
     }
 

--- a/server/src/main/java/ppalatjyo/server/domain/quiz/domain/Quiz.java
+++ b/server/src/main/java/ppalatjyo/server/domain/quiz/domain/Quiz.java
@@ -23,6 +23,10 @@ public class Quiz extends BaseEntity {
     @Column(name = "quiz_id")
     private Long id;
     private String title;
+    private String description;
+
+    @Enumerated(EnumType.STRING)
+    private QuizVisibility visibility;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
@@ -43,6 +47,21 @@ public class Quiz extends BaseEntity {
                 .title(title)
                 .user(user)
                 .questions(new ArrayList<>())
+                .visibility(QuizVisibility.PRIVATE)
+                .build();
+    }
+
+    public static Quiz createQuiz(String title, User user, String description, QuizVisibility visibility) {
+        if (user.getRole() == UserRole.GUEST) {
+            throw new GuestCannotCreateQuizException();
+        }
+
+        return Quiz.builder()
+                .title(title)
+                .user(user)
+                .description(description)
+                .questions(new ArrayList<>())
+                .visibility(visibility)
                 .build();
     }
 

--- a/server/src/main/java/ppalatjyo/server/domain/quiz/domain/QuizVisibility.java
+++ b/server/src/main/java/ppalatjyo/server/domain/quiz/domain/QuizVisibility.java
@@ -1,0 +1,5 @@
+package ppalatjyo.server.domain.quiz.domain;
+
+public enum QuizVisibility {
+    PUBLIC, PRIVATE
+}

--- a/server/src/main/java/ppalatjyo/server/domain/quiz/dto/CreateAnswerRequestDto.java
+++ b/server/src/main/java/ppalatjyo/server/domain/quiz/dto/CreateAnswerRequestDto.java
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 
 @Data
-public class QuestionUpdateRequestDto {
+public class CreateAnswerRequestDto {
     @NotNull(message = "questionId는 필수입니다.")
     private Long questionId;
     @NotBlank(message = "content는 빈 값일 수 없습니다.")

--- a/server/src/main/java/ppalatjyo/server/domain/quiz/dto/CreateQuestionRequestDto.java
+++ b/server/src/main/java/ppalatjyo/server/domain/quiz/dto/CreateQuestionRequestDto.java
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 
 @Data
-public class QuestionCreateRequestDto {
+public class CreateQuestionRequestDto {
     @NotNull(message = "quizId는 필수입니다.")
     private Long quizId;
     @NotBlank(message = "content는 빈 값일 수 없습니다.")

--- a/server/src/main/java/ppalatjyo/server/domain/quiz/dto/CreateQuizRequestDto.java
+++ b/server/src/main/java/ppalatjyo/server/domain/quiz/dto/CreateQuizRequestDto.java
@@ -1,0 +1,14 @@
+package ppalatjyo.server.domain.quiz.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import ppalatjyo.server.domain.quiz.domain.QuizVisibility;
+
+@Data
+@AllArgsConstructor
+public class CreateQuizRequestDto {
+    private Long userId;
+    private String title;
+    private String description;
+    private QuizVisibility visibility;
+}

--- a/server/src/main/java/ppalatjyo/server/domain/quiz/dto/UpdateAnswerRequestDto.java
+++ b/server/src/main/java/ppalatjyo/server/domain/quiz/dto/UpdateAnswerRequestDto.java
@@ -3,7 +3,7 @@ package ppalatjyo.server.domain.quiz.dto;
 import lombok.Data;
 
 @Data
-public class AnswerUpdateRequestDto {
+public class UpdateAnswerRequestDto {
     private Long answerId;
     private String content;
 }

--- a/server/src/main/java/ppalatjyo/server/domain/quiz/dto/UpdateQuestionRequestDto.java
+++ b/server/src/main/java/ppalatjyo/server/domain/quiz/dto/UpdateQuestionRequestDto.java
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 
 @Data
-public class AnswerCreateRequestDto {
+public class UpdateQuestionRequestDto {
     @NotNull(message = "questionId는 필수입니다.")
     private Long questionId;
     @NotBlank(message = "content는 빈 값일 수 없습니다.")

--- a/server/src/test/java/ppalatjyo/server/domain/quiz/AnswerServiceTest.java
+++ b/server/src/test/java/ppalatjyo/server/domain/quiz/AnswerServiceTest.java
@@ -7,12 +7,11 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import ppalatjyo.server.domain.quiz.AnswerService;
 import ppalatjyo.server.domain.quiz.domain.Answer;
 import ppalatjyo.server.domain.quiz.domain.Question;
 import ppalatjyo.server.domain.quiz.domain.Quiz;
-import ppalatjyo.server.domain.quiz.dto.AnswerCreateRequestDto;
-import ppalatjyo.server.domain.quiz.dto.AnswerUpdateRequestDto;
+import ppalatjyo.server.domain.quiz.dto.CreateAnswerRequestDto;
+import ppalatjyo.server.domain.quiz.dto.UpdateAnswerRequestDto;
 import ppalatjyo.server.domain.quiz.repository.AnswerRepository;
 import ppalatjyo.server.domain.quiz.repository.QuestionRepository;
 import ppalatjyo.server.domain.user.domain.User;
@@ -44,7 +43,7 @@ class AnswerServiceTest {
         Long questionId = 1L;
         String content = "answer";
 
-        AnswerCreateRequestDto requestDto = new AnswerCreateRequestDto();
+        CreateAnswerRequestDto requestDto = new CreateAnswerRequestDto();
         requestDto.setQuestionId(questionId);
         requestDto.setContent(content);
 
@@ -75,7 +74,7 @@ class AnswerServiceTest {
         when(answerRepository.findById(answerId)).thenReturn(Optional.of(answer));
 
         String newContent = "newContent";
-        AnswerUpdateRequestDto requestDto = new AnswerUpdateRequestDto();
+        UpdateAnswerRequestDto requestDto = new UpdateAnswerRequestDto();
         requestDto.setAnswerId(answerId);
         requestDto.setContent(newContent);
 

--- a/server/src/test/java/ppalatjyo/server/domain/quiz/QuestionServiceTest.java
+++ b/server/src/test/java/ppalatjyo/server/domain/quiz/QuestionServiceTest.java
@@ -8,11 +8,10 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.transaction.annotation.Transactional;
-import ppalatjyo.server.domain.quiz.QuestionService;
 import ppalatjyo.server.domain.quiz.domain.Question;
 import ppalatjyo.server.domain.quiz.domain.Quiz;
-import ppalatjyo.server.domain.quiz.dto.QuestionCreateRequestDto;
-import ppalatjyo.server.domain.quiz.dto.QuestionUpdateRequestDto;
+import ppalatjyo.server.domain.quiz.dto.CreateQuestionRequestDto;
+import ppalatjyo.server.domain.quiz.dto.UpdateQuestionRequestDto;
 import ppalatjyo.server.domain.quiz.repository.QuestionRepository;
 import ppalatjyo.server.domain.quiz.repository.QuizRepository;
 import ppalatjyo.server.domain.user.domain.User;
@@ -45,12 +44,12 @@ class QuestionServiceTest {
         Long quizId = 1L;
         when(quizRepository.findById(quizId)).thenReturn(Optional.of(quiz));
 
-        QuestionCreateRequestDto questionCreateRequestDto = new QuestionCreateRequestDto();
-        questionCreateRequestDto.setQuizId(quizId);
-        questionCreateRequestDto.setContent("content");
+        CreateQuestionRequestDto createQuestionRequestDto = new CreateQuestionRequestDto();
+        createQuestionRequestDto.setQuizId(quizId);
+        createQuestionRequestDto.setContent("content");
 
         // when
-        questionService.create(questionCreateRequestDto);
+        questionService.create(createQuestionRequestDto);
 
         // then
         ArgumentCaptor<Question> captor = ArgumentCaptor.forClass(Question.class);
@@ -60,7 +59,7 @@ class QuestionServiceTest {
         assertThat(question).isNotNull();
         assertThat(question.getQuiz()).isEqualTo(quiz);
         assertThat(quiz.getQuestions().getFirst()).isEqualTo(question);
-        assertThat(question.getContent()).isEqualTo(questionCreateRequestDto.getContent());
+        assertThat(question.getContent()).isEqualTo(createQuestionRequestDto.getContent());
     }
 
     @Test
@@ -74,15 +73,15 @@ class QuestionServiceTest {
 
         when(questionRepository.findById(questionId)).thenReturn(Optional.of(question));
 
-        QuestionUpdateRequestDto questionUpdateRequestDto = new QuestionUpdateRequestDto();
-        questionUpdateRequestDto.setQuestionId(questionId);
-        questionUpdateRequestDto.setContent("newContent");
+        UpdateQuestionRequestDto updateQuestionRequestDto = new UpdateQuestionRequestDto();
+        updateQuestionRequestDto.setQuestionId(questionId);
+        updateQuestionRequestDto.setContent("newContent");
 
         // when
-        questionService.updateQuestion(questionUpdateRequestDto);
+        questionService.updateQuestion(updateQuestionRequestDto);
 
         // then
-        assertThat(question.getContent()).isEqualTo(questionUpdateRequestDto.getContent());
+        assertThat(question.getContent()).isEqualTo(updateQuestionRequestDto.getContent());
     }
 
     @Test

--- a/server/src/test/java/ppalatjyo/server/domain/quiz/QuizServiceTest.java
+++ b/server/src/test/java/ppalatjyo/server/domain/quiz/QuizServiceTest.java
@@ -3,12 +3,15 @@ package ppalatjyo.server.domain.quiz;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.transaction.annotation.Transactional;
 import ppalatjyo.server.domain.quiz.QuizService;
 import ppalatjyo.server.domain.quiz.domain.Quiz;
+import ppalatjyo.server.domain.quiz.domain.QuizVisibility;
+import ppalatjyo.server.domain.quiz.dto.CreateQuizRequestDto;
 import ppalatjyo.server.domain.quiz.repository.QuizRepository;
 import ppalatjyo.server.domain.user.UserRepository;
 import ppalatjyo.server.domain.user.domain.User;
@@ -36,17 +39,26 @@ class QuizServiceTest {
     void createQuiz() {
         // given
         String title = "quiz";
+        String description = "quiz description";
+        QuizVisibility visibility = QuizVisibility.PUBLIC;
         User member = User.createMember("user", "", "");
 
         Long userId = 1L;
 
+        CreateQuizRequestDto createQuizRequestDto = new CreateQuizRequestDto(userId, title, description, visibility);
+
         when(userRepository.findById(userId)).thenReturn(Optional.of(member));
 
         // when
-        quizService.create(title, userId);
+        quizService.create(createQuizRequestDto);
 
         // then
-        verify(quizRepository, times(1)).save(any(Quiz.class));
+        ArgumentCaptor<Quiz> captor = ArgumentCaptor.forClass(Quiz.class);
+        verify(quizRepository).save(captor.capture());
+        Quiz quiz = captor.getValue();
+        assertThat(quiz.getTitle()).isEqualTo(title);
+        assertThat(quiz.getDescription()).isEqualTo(description);
+        assertThat(quiz.getVisibility()).isEqualTo(visibility);
     }
 
     @Test

--- a/server/src/test/java/ppalatjyo/server/domain/quiz/domain/QuizTest.java
+++ b/server/src/test/java/ppalatjyo/server/domain/quiz/domain/QuizTest.java
@@ -21,13 +21,17 @@ class QuizTest {
         // given
         String name = "quiz";
         User member = User.createMember("author", "test@email.com", "google");
+        String description = "description";
+        QuizVisibility visibility = QuizVisibility.PUBLIC;
 
         // when
-        Quiz quiz = Quiz.createQuiz(name, member);
+        Quiz quiz = Quiz.createQuiz(name, member, description, visibility);
 
         // then
         assertThat(quiz.getTitle()).isEqualTo(name);
         assertThat(quiz.getUser()).isEqualTo(member);
+        assertThat(quiz.getDescription()).isEqualTo(description);
+        assertThat(quiz.getVisibility()).isEqualTo(visibility);
     }
 
     @Test


### PR DESCRIPTION
## 관련 이슈

- #124

## 변경 사항

- Quiz 도메인에 `description`과 `visibility` 필드를 추가하였습니다.
  - `visibility` 필드는 enum 타입의 `QuizVisibility` 클래스를 String Enumerated로 갖습니다.
  - `description`과 `visibility`를 매개변수로 받는 펙토리 메서드를 추가하였습니다.
- `QuizService`의 `create()`를 수정하였습니다.
  - 이제 매개변수로 `CreateQuizRequestDto`를 받습니다.
- 기존 Dto 네이밍을 `QuizCreateRequestDto` 에서 `CreateQuizRequestDto`로 동사(커멘드)가 앞으로 오도록 리펙토링 하였습니다.
- 관련 테스트를 수정하였습니다.

## 고려 사항 및 주의 사항 (선택)

- Dto 클래스에 `Request`와 `Response`로 Dto임을 구분할 수 있으므로 `Dto`는 빼도 되지 않을까요? -> 프론트엔드와 네이밍 통일 가능.
- 각 도메인의 수정/삭제에서 생성자 user 인지 확인하는 접근 권한 로직이 필요합니다.

## 추가 정보 (선택)
