### PR TITLE
[FEATURE #120]: 멤버로 가입 구현

### DIFF
--- a/server/src/main/java/ppalatjyo/server/domain/user/UserService.java
+++ b/server/src/main/java/ppalatjyo/server/domain/user/UserService.java
@@ -23,11 +23,10 @@ public class UserService {
         return saved.getId();
     }
 
-    public JoinAsMemberResponseDto joinAsMember(String nickname, String oAuthEmail, OAuthProvider provider) {
+    public long joinAsMember(String nickname, String oAuthEmail, OAuthProvider provider) {
         User member = User.createMember(nickname, oAuthEmail, provider);
-        userRepository.save(member);
-
-        return new JoinAsMemberResponseDto("", "");
+        User saved = userRepository.save(member);
+        return saved.getId();
     }
 
     public void promoteGuestToMember(Long userId, String oAuthEmail, OAuthProvider provider) {

--- a/server/src/main/java/ppalatjyo/server/domain/user/UserService.java
+++ b/server/src/main/java/ppalatjyo/server/domain/user/UserService.java
@@ -3,6 +3,7 @@ package ppalatjyo.server.domain.user;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import ppalatjyo.server.domain.user.domain.OAuthProvider;
 import ppalatjyo.server.domain.user.domain.User;
 import ppalatjyo.server.domain.user.dto.JoinAsMemberResponseDto;
 import ppalatjyo.server.domain.user.exception.UserNotFoundException;
@@ -22,16 +23,16 @@ public class UserService {
         return saved.getId();
     }
 
-    public JoinAsMemberResponseDto joinAsMember(String nickname, String oAuthEmail, String oAuthProvider) {
-        User member = User.createMember(nickname, oAuthEmail, oAuthProvider);
+    public JoinAsMemberResponseDto joinAsMember(String nickname, String oAuthEmail, OAuthProvider provider) {
+        User member = User.createMember(nickname, oAuthEmail, provider);
         userRepository.save(member);
 
         return new JoinAsMemberResponseDto("", "");
     }
 
-    public void promoteGuestToMember(Long userId, String oAuthEmail, String oAuthProvider) {
+    public void promoteGuestToMember(Long userId, String oAuthEmail, OAuthProvider provider) {
         User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
-        user.promoteGuestToMember(oAuthEmail, oAuthProvider);
+        user.promoteGuestToMember(oAuthEmail, provider);
     }
 
     public void changeNickname(Long userId, String newNickname) {

--- a/server/src/main/java/ppalatjyo/server/domain/user/domain/OAuthProvider.java
+++ b/server/src/main/java/ppalatjyo/server/domain/user/domain/OAuthProvider.java
@@ -1,0 +1,5 @@
+package ppalatjyo.server.domain.user.domain;
+
+public enum OAuthProvider {
+    GITHUB
+}

--- a/server/src/main/java/ppalatjyo/server/domain/user/domain/User.java
+++ b/server/src/main/java/ppalatjyo/server/domain/user/domain/User.java
@@ -21,7 +21,9 @@ public class User extends BaseEntity {
     private Long id;
     private String nickname;
     private String oAuthEmail;
-    private String oAuthProvider;
+
+    @Enumerated(EnumType.STRING)
+    private OAuthProvider oAuthProvider;
 
     @Enumerated(value = EnumType.STRING)
     private UserRole role;
@@ -38,22 +40,22 @@ public class User extends BaseEntity {
                 .build();
     }
 
-    public static User createMember(String nickname, String oAuthEmail, String oAuthProvider) {
+    public static User createMember(String nickname, String oAuthEmail, OAuthProvider provider) {
         return User.builder()
                 .nickname(nickname)
                 .role(UserRole.MEMBER)
                 .oAuthEmail(oAuthEmail)
-                .oAuthProvider(oAuthProvider)
+                .oAuthProvider(provider)
                 .build();
     }
 
-    public void promoteGuestToMember(String oAuthEmail, String oAuthProvider) {
+    public void promoteGuestToMember(String oAuthEmail, OAuthProvider provider) {
         if (this.role == UserRole.MEMBER || this.role == UserRole.ADMIN) {
             throw new UserAlreadyMemberException();
         }
 
         this.oAuthEmail = oAuthEmail;
-        this.oAuthProvider = oAuthProvider;
+        this.oAuthProvider = provider;
         this.role = UserRole.MEMBER;
     }
 

--- a/server/src/main/java/ppalatjyo/server/global/AppConfig.java
+++ b/server/src/main/java/ppalatjyo/server/global/AppConfig.java
@@ -1,0 +1,14 @@
+package ppalatjyo.server.global;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class AppConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/server/src/main/java/ppalatjyo/server/global/auth/AuthController.java
+++ b/server/src/main/java/ppalatjyo/server/global/auth/AuthController.java
@@ -6,6 +6,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import ppalatjyo.server.global.auth.dto.JoinAsGuestRequestDto;
 import ppalatjyo.server.global.auth.dto.JoinAsGuestResponseDto;
+import ppalatjyo.server.global.auth.dto.JoinAsMemberByGitHubRequestDto;
+import ppalatjyo.server.global.auth.dto.JoinAsMemberByGitHubResponseDto;
 import ppalatjyo.server.global.auth.service.AuthService;
 
 @RestController
@@ -18,6 +20,11 @@ public class AuthController {
     @PostMapping("/join/guest")
     public ResponseEntity<JoinAsGuestResponseDto> guestLogin(@RequestBody JoinAsGuestRequestDto requestDto, HttpServletResponse response) {
         return ResponseEntity.ok(authService.joinAsGuest(requestDto.getNickname(), response));
+    }
+
+    @PostMapping("/join/github")
+    public ResponseEntity<JoinAsMemberByGitHubResponseDto> joinAsMemberByGitHub(@RequestBody JoinAsMemberByGitHubRequestDto requestDto, HttpServletResponse response) {
+        return ResponseEntity.ok(authService.joinAsMemberByGitHub(requestDto, response));
     }
 
     @GetMapping("/tokens")

--- a/server/src/main/java/ppalatjyo/server/global/auth/AuthController.java
+++ b/server/src/main/java/ppalatjyo/server/global/auth/AuthController.java
@@ -6,6 +6,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import ppalatjyo.server.global.auth.dto.JoinAsGuestRequestDto;
 import ppalatjyo.server.global.auth.dto.JoinAsGuestResponseDto;
+import ppalatjyo.server.global.auth.service.AuthService;
 
 @RestController
 @RequiredArgsConstructor

--- a/server/src/main/java/ppalatjyo/server/global/auth/AuthController.java
+++ b/server/src/main/java/ppalatjyo/server/global/auth/AuthController.java
@@ -4,8 +4,8 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import ppalatjyo.server.global.auth.dto.GuestLoginRequestDto;
-import ppalatjyo.server.global.auth.dto.SignUpAsGuestResponseDto;
+import ppalatjyo.server.global.auth.dto.JoinAsGuestRequestDto;
+import ppalatjyo.server.global.auth.dto.JoinAsGuestResponseDto;
 
 @RestController
 @RequiredArgsConstructor
@@ -14,9 +14,9 @@ public class AuthController {
 
     private final AuthService authService;
 
-    @PostMapping("/sign-up/guest")
-    public ResponseEntity<SignUpAsGuestResponseDto> guestLogin(@RequestBody GuestLoginRequestDto requestDto, HttpServletResponse response) {
-        return ResponseEntity.ok(authService.singUpAsGuest(requestDto.getNickname(), response));
+    @PostMapping("/join/guest")
+    public ResponseEntity<JoinAsGuestResponseDto> guestLogin(@RequestBody JoinAsGuestRequestDto requestDto, HttpServletResponse response) {
+        return ResponseEntity.ok(authService.joinAsGuest(requestDto.getNickname(), response));
     }
 
     @GetMapping("/tokens")

--- a/server/src/main/java/ppalatjyo/server/global/auth/AuthControllerAdvice.java
+++ b/server/src/main/java/ppalatjyo/server/global/auth/AuthControllerAdvice.java
@@ -1,18 +1,31 @@
 package ppalatjyo.server.global.auth;
 
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import ppalatjyo.server.global.auth.exception.GitHubOAuthException;
 import ppalatjyo.server.global.auth.exception.RefreshTokenException;
 import ppalatjyo.server.global.error.ErrorResponseDto;
 
 @RestControllerAdvice(assignableTypes = {AuthController.class})
+@Order(Ordered.HIGHEST_PRECEDENCE)
+@Slf4j
 public class AuthControllerAdvice {
 
     @ExceptionHandler(RefreshTokenException.class)
     public ResponseEntity<ErrorResponseDto> handleRefreshTokenException() {
         ErrorResponseDto errorDto = ErrorResponseDto.commonError("Refresh Failed", "/api/auth/tokens");
         return ResponseEntity.status(HttpStatus.FORBIDDEN).body(errorDto);
+    }
+
+    @ExceptionHandler(GitHubOAuthException.class)
+    public ResponseEntity<ErrorResponseDto> handleGitHubOAuthException(GitHubOAuthException ex, HttpServletRequest request) {
+        ErrorResponseDto errorDto = ErrorResponseDto.commonError("Authenticating with GitHub failed. Authorization code has expired or invalid.", request.getRequestURI());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorDto);
     }
 }

--- a/server/src/main/java/ppalatjyo/server/global/auth/AuthControllerAdvice.java
+++ b/server/src/main/java/ppalatjyo/server/global/auth/AuthControllerAdvice.java
@@ -4,6 +4,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import ppalatjyo.server.global.auth.exception.RefreshTokenException;
 import ppalatjyo.server.global.error.ErrorResponseDto;
 
 @RestControllerAdvice(assignableTypes = {AuthController.class})

--- a/server/src/main/java/ppalatjyo/server/global/auth/AuthService.java
+++ b/server/src/main/java/ppalatjyo/server/global/auth/AuthService.java
@@ -6,7 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import ppalatjyo.server.global.auth.domain.RefreshToken;
-import ppalatjyo.server.global.auth.dto.SignUpAsGuestResponseDto;
+import ppalatjyo.server.global.auth.dto.JoinAsGuestResponseDto;
 import ppalatjyo.server.global.auth.dto.TokenReissueResponseDto;
 import ppalatjyo.server.global.auth.repository.RefreshTokenRepository;
 import ppalatjyo.server.global.security.jwt.JwtTokenProvider;
@@ -24,7 +24,7 @@ public class AuthService {
     private final UserRepository userRepository;
     private final RefreshTokenRepository refreshTokenRepository;
 
-    public SignUpAsGuestResponseDto singUpAsGuest(String nickname, HttpServletResponse response) {
+    public JoinAsGuestResponseDto joinAsGuest(String nickname, HttpServletResponse response) {
         long userId = userService.joinAsGuest(nickname);
 
         String accessToken = jwtTokenProvider.createAccessToken(userId);
@@ -32,7 +32,7 @@ public class AuthService {
 
         storeRefreshTokenInCookie(response, refreshToken);
 
-        return new SignUpAsGuestResponseDto(accessToken);
+        return new JoinAsGuestResponseDto(accessToken);
     }
 
     public TokenReissueResponseDto reissue(String oldRefreshToken, HttpServletResponse response) {

--- a/server/src/main/java/ppalatjyo/server/global/auth/AuthService.java
+++ b/server/src/main/java/ppalatjyo/server/global/auth/AuthService.java
@@ -7,6 +7,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import ppalatjyo.server.global.auth.domain.RefreshToken;
 import ppalatjyo.server.global.auth.dto.JoinAsGuestResponseDto;
+import ppalatjyo.server.global.auth.dto.JoinAsMemberByGitHubRequestDto;
+import ppalatjyo.server.global.auth.dto.JoinAsMemberByGitHubResponseDto;
 import ppalatjyo.server.global.auth.dto.TokenReissueResponseDto;
 import ppalatjyo.server.global.auth.repository.RefreshTokenRepository;
 import ppalatjyo.server.global.security.jwt.JwtTokenProvider;
@@ -75,5 +77,9 @@ public class AuthService {
         cookie.setPath("/");
         cookie.setHttpOnly(true);
         response.addCookie(cookie);
+    }
+
+    public JoinAsMemberByGitHubResponseDto joinAsMemberByGitHub(JoinAsMemberByGitHubRequestDto requestDto, HttpServletResponse response) {
+        return null;
     }
 }

--- a/server/src/main/java/ppalatjyo/server/global/auth/AuthService.java
+++ b/server/src/main/java/ppalatjyo/server/global/auth/AuthService.java
@@ -5,6 +5,8 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import ppalatjyo.server.domain.user.domain.OAuthProvider;
+import ppalatjyo.server.domain.user.dto.JoinAsMemberResponseDto;
 import ppalatjyo.server.global.auth.domain.RefreshToken;
 import ppalatjyo.server.global.auth.dto.JoinAsGuestResponseDto;
 import ppalatjyo.server.global.auth.dto.JoinAsMemberByGitHubRequestDto;
@@ -35,6 +37,17 @@ public class AuthService {
         storeRefreshTokenInCookie(response, refreshToken);
 
         return new JoinAsGuestResponseDto(accessToken);
+    }
+
+    public JoinAsMemberByGitHubResponseDto joinAsMemberByGitHub(JoinAsMemberByGitHubRequestDto requestDto, HttpServletResponse response) {
+
+        long userId = userService.joinAsMember(requestDto.getNickname(), "", OAuthProvider.GITHUB);
+
+        String accessToken = jwtTokenProvider.createAccessToken(userId);
+        String refreshToken = createAndSaveRefreshToken(userId);
+        storeRefreshTokenInCookie(response, refreshToken);
+
+        return new JoinAsMemberByGitHubResponseDto(accessToken);
     }
 
     public TokenReissueResponseDto reissue(String oldRefreshToken, HttpServletResponse response) {
@@ -77,9 +90,5 @@ public class AuthService {
         cookie.setPath("/");
         cookie.setHttpOnly(true);
         response.addCookie(cookie);
-    }
-
-    public JoinAsMemberByGitHubResponseDto joinAsMemberByGitHub(JoinAsMemberByGitHubRequestDto requestDto, HttpServletResponse response) {
-        return null;
     }
 }

--- a/server/src/main/java/ppalatjyo/server/global/auth/dto/JoinAsGuestRequestDto.java
+++ b/server/src/main/java/ppalatjyo/server/global/auth/dto/JoinAsGuestRequestDto.java
@@ -3,6 +3,6 @@ package ppalatjyo.server.global.auth.dto;
 import lombok.Data;
 
 @Data
-public class GuestLoginRequestDto {
+public class JoinAsGuestRequestDto {
     private String nickname;
 }

--- a/server/src/main/java/ppalatjyo/server/global/auth/dto/JoinAsGuestResponseDto.java
+++ b/server/src/main/java/ppalatjyo/server/global/auth/dto/JoinAsGuestResponseDto.java
@@ -5,6 +5,6 @@ import lombok.Data;
 
 @Data
 @AllArgsConstructor
-public class SignUpAsGuestResponseDto {
+public class JoinAsGuestResponseDto {
     private String accessToken;
 }

--- a/server/src/main/java/ppalatjyo/server/global/auth/dto/JoinAsMemberByGitHubRequestDto.java
+++ b/server/src/main/java/ppalatjyo/server/global/auth/dto/JoinAsMemberByGitHubRequestDto.java
@@ -1,0 +1,14 @@
+package ppalatjyo.server.global.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class JoinAsMemberByGitHubRequestDto {
+    private Long userId;
+    private String nickname;
+    private String code;
+}

--- a/server/src/main/java/ppalatjyo/server/global/auth/dto/JoinAsMemberByGitHubResponseDto.java
+++ b/server/src/main/java/ppalatjyo/server/global/auth/dto/JoinAsMemberByGitHubResponseDto.java
@@ -1,0 +1,8 @@
+package ppalatjyo.server.global.auth.dto;
+
+import lombok.Data;
+
+@Data
+public class JoinAsMemberByGitHubResponseDto {
+    private String accessToken;
+}

--- a/server/src/main/java/ppalatjyo/server/global/auth/dto/JoinAsMemberByGitHubResponseDto.java
+++ b/server/src/main/java/ppalatjyo/server/global/auth/dto/JoinAsMemberByGitHubResponseDto.java
@@ -1,8 +1,10 @@
 package ppalatjyo.server.global.auth.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Data;
 
 @Data
+@AllArgsConstructor
 public class JoinAsMemberByGitHubResponseDto {
     private String accessToken;
 }

--- a/server/src/main/java/ppalatjyo/server/global/auth/exception/GitHubAccessTokenExchangeException.java
+++ b/server/src/main/java/ppalatjyo/server/global/auth/exception/GitHubAccessTokenExchangeException.java
@@ -1,0 +1,4 @@
+package ppalatjyo.server.global.auth.exception;
+
+public class GitHubAccessTokenExchangeException extends RuntimeException {
+}

--- a/server/src/main/java/ppalatjyo/server/global/auth/exception/GitHubAccessTokenExchangeException.java
+++ b/server/src/main/java/ppalatjyo/server/global/auth/exception/GitHubAccessTokenExchangeException.java
@@ -1,4 +1,4 @@
 package ppalatjyo.server.global.auth.exception;
 
-public class GitHubAccessTokenExchangeException extends RuntimeException {
+public class GitHubAccessTokenExchangeException extends GitHubOAuthException {
 }

--- a/server/src/main/java/ppalatjyo/server/global/auth/exception/GitHubEmailFetchingFailedException.java
+++ b/server/src/main/java/ppalatjyo/server/global/auth/exception/GitHubEmailFetchingFailedException.java
@@ -1,4 +1,13 @@
 package ppalatjyo.server.global.auth.exception;
 
-public class GitHubEmailFetchingFailedException extends RuntimeException {
+import org.springframework.web.client.RestClientException;
+
+public class GitHubEmailFetchingFailedException extends GitHubOAuthException {
+    public GitHubEmailFetchingFailedException(RestClientException e) {
+        super(e);
+    }
+
+    public GitHubEmailFetchingFailedException() {
+        super();
+    }
 }

--- a/server/src/main/java/ppalatjyo/server/global/auth/exception/GitHubEmailFetchingFailedException.java
+++ b/server/src/main/java/ppalatjyo/server/global/auth/exception/GitHubEmailFetchingFailedException.java
@@ -1,0 +1,4 @@
+package ppalatjyo.server.global.auth.exception;
+
+public class GitHubEmailFetchingFailedException extends RuntimeException {
+}

--- a/server/src/main/java/ppalatjyo/server/global/auth/exception/GitHubNoPrimaryEmailException.java
+++ b/server/src/main/java/ppalatjyo/server/global/auth/exception/GitHubNoPrimaryEmailException.java
@@ -1,0 +1,4 @@
+package ppalatjyo.server.global.auth.exception;
+
+public class GitHubNoPrimaryEmailException extends RuntimeException {
+}

--- a/server/src/main/java/ppalatjyo/server/global/auth/exception/GitHubNoPrimaryEmailException.java
+++ b/server/src/main/java/ppalatjyo/server/global/auth/exception/GitHubNoPrimaryEmailException.java
@@ -1,4 +1,4 @@
 package ppalatjyo.server.global.auth.exception;
 
-public class GitHubNoPrimaryEmailException extends RuntimeException {
+public class GitHubNoPrimaryEmailException extends GitHubOAuthException {
 }

--- a/server/src/main/java/ppalatjyo/server/global/auth/exception/GitHubOAuthException.java
+++ b/server/src/main/java/ppalatjyo/server/global/auth/exception/GitHubOAuthException.java
@@ -1,0 +1,13 @@
+package ppalatjyo.server.global.auth.exception;
+
+import org.springframework.web.client.RestClientException;
+
+public class GitHubOAuthException extends RuntimeException{
+    public GitHubOAuthException(RestClientException e) {
+        super(e);
+    }
+
+    public GitHubOAuthException() {
+        super();
+    }
+}

--- a/server/src/main/java/ppalatjyo/server/global/auth/exception/RefreshTokenException.java
+++ b/server/src/main/java/ppalatjyo/server/global/auth/exception/RefreshTokenException.java
@@ -1,4 +1,4 @@
-package ppalatjyo.server.global.auth;
+package ppalatjyo.server.global.auth.exception;
 
 public class RefreshTokenException extends RuntimeException {
     public RefreshTokenException(String message) {

--- a/server/src/main/java/ppalatjyo/server/global/auth/service/AuthService.java
+++ b/server/src/main/java/ppalatjyo/server/global/auth/service/AuthService.java
@@ -27,6 +27,7 @@ public class AuthService {
     private final UserService userService;
     private final UserRepository userRepository;
     private final RefreshTokenRepository refreshTokenRepository;
+    private final GitHubOAuthService gitHubOAuthService;
 
     public JoinAsGuestResponseDto joinAsGuest(String nickname, HttpServletResponse response) {
         long userId = userService.joinAsGuest(nickname);
@@ -40,8 +41,8 @@ public class AuthService {
     }
 
     public JoinAsMemberByGitHubResponseDto joinAsMemberByGitHub(JoinAsMemberByGitHubRequestDto requestDto, HttpServletResponse response) {
-
-        long userId = userService.joinAsMember(requestDto.getNickname(), "", OAuthProvider.GITHUB);
+        String code = gitHubOAuthService.getEmailFromCode(requestDto.getCode());
+        long userId = userService.joinAsMember(requestDto.getNickname(), code, OAuthProvider.GITHUB);
 
         String accessToken = jwtTokenProvider.createAccessToken(userId);
         String refreshToken = createAndSaveRefreshToken(userId);

--- a/server/src/main/java/ppalatjyo/server/global/auth/service/AuthService.java
+++ b/server/src/main/java/ppalatjyo/server/global/auth/service/AuthService.java
@@ -1,4 +1,4 @@
-package ppalatjyo.server.global.auth;
+package ppalatjyo.server.global.auth.service;
 
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
@@ -6,7 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import ppalatjyo.server.domain.user.domain.OAuthProvider;
-import ppalatjyo.server.domain.user.dto.JoinAsMemberResponseDto;
+import ppalatjyo.server.global.auth.exception.RefreshTokenException;
 import ppalatjyo.server.global.auth.domain.RefreshToken;
 import ppalatjyo.server.global.auth.dto.JoinAsGuestResponseDto;
 import ppalatjyo.server.global.auth.dto.JoinAsMemberByGitHubRequestDto;

--- a/server/src/main/java/ppalatjyo/server/global/auth/service/GitHubOAuthService.java
+++ b/server/src/main/java/ppalatjyo/server/global/auth/service/GitHubOAuthService.java
@@ -1,0 +1,79 @@
+package ppalatjyo.server.global.auth.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import ppalatjyo.server.global.auth.exception.GitHubAccessTokenExchangeException;
+import ppalatjyo.server.global.auth.exception.GitHubEmailFetchingFailedException;
+import ppalatjyo.server.global.auth.exception.GitHubNoPrimaryEmailException;
+
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class GitHubOAuthService {
+
+    private final RestTemplate restTemplate;
+    @Value("${oauth.github.client-id}")
+    private String clientId;
+    @Value("${oauth.github.client-secret}")
+    private String clientSecret;
+
+    public String getEmailFromCode(String code) {
+        String accessToken = requestAccessToken(code);
+        return requestEmail(accessToken);
+    }
+
+    private String requestAccessToken(String code) {
+        String tokenUrl = "https://github.com/login/oauth/access_token";
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+
+        Map<String, String> request = Map.of(
+                "client_id", clientId,
+                "client_secret", clientSecret,
+                "code", code
+        );
+
+        HttpEntity<Map<String, String>> requestEntity = new HttpEntity<>(request, headers);
+
+        ResponseEntity<Map> response = restTemplate.postForEntity(tokenUrl, requestEntity, Map.class);
+
+        if (response.getStatusCode() != HttpStatus.OK || response.getBody() == null) {
+            throw new GitHubAccessTokenExchangeException();
+        }
+
+        return (String) response.getBody().get("access_token");
+    }
+
+    private String requestEmail(String accessToken) {
+        String userEmailUrl = "https://api.github.com/user/emails";
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBasicAuth(accessToken);
+        headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+
+        HttpEntity<Void> entity = new HttpEntity<>(headers);
+
+        ResponseEntity<List> response = restTemplate.exchange(userEmailUrl, HttpMethod.GET, entity, List.class);
+        if (response.getStatusCode() != HttpStatus.OK || response.getBody() == null) {
+            throw new GitHubEmailFetchingFailedException();
+        }
+
+        // GitHub API는 기본 이메일이 여러 개일 수 있으므로 primary & verified된 것 사용
+        for (Object item : response.getBody()) {
+            if (item instanceof Map emailInfo) {
+                if (Boolean.TRUE.equals(emailInfo.get("primary")) && Boolean.TRUE.equals(emailInfo.get("verified"))) {
+                    return (String) emailInfo.get("email");
+                }
+            }
+        }
+
+        throw new GitHubNoPrimaryEmailException();
+    }
+}

--- a/server/src/main/java/ppalatjyo/server/global/error/GlobalExceptionHandler.java
+++ b/server/src/main/java/ppalatjyo/server/global/error/GlobalExceptionHandler.java
@@ -2,6 +2,8 @@ package ppalatjyo.server.global.error;
 
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
@@ -15,6 +17,7 @@ import java.util.stream.Collectors;
 
 @RestControllerAdvice
 @Slf4j
+@Order(Ordered.LOWEST_PRECEDENCE)
 public class GlobalExceptionHandler {
 
     /**

--- a/server/src/test/java/ppalatjyo/server/domain/game/GameServiceTest.java
+++ b/server/src/test/java/ppalatjyo/server/domain/game/GameServiceTest.java
@@ -54,7 +54,7 @@ class GameServiceTest {
         // given
         Long lobbyId = 1L;
 
-        User host = User.createMember("host", "email", "provider");
+        User host = User.createMember("host", "email", null);
         User participant = User.createGuest("user");
 
         Quiz quiz = Quiz.createQuiz("quiz", host);
@@ -187,7 +187,7 @@ class GameServiceTest {
         // given
         String answer = "answer";
 
-        Quiz quiz = Quiz.createQuiz("quiz", User.createMember("n", "e", "p"));
+        Quiz quiz = Quiz.createQuiz("quiz", User.createMember("n", "e", null));
         Question question1 = Question.create(quiz, "question1");
         Answer.createAnswer(question1, answer);
 
@@ -234,7 +234,7 @@ class GameServiceTest {
         String answer = "answer1";
         String wrongAnswer = "wrongAnswer";
 
-        Quiz quiz = Quiz.createQuiz("quiz", User.createMember("n", "e", "p"));
+        Quiz quiz = Quiz.createQuiz("quiz", User.createMember("n", "e", null));
         Question question1 = Question.create(quiz, "question1");
         Answer.createAnswer(question1, answer);
 
@@ -288,7 +288,7 @@ class GameServiceTest {
     }
 
     private Quiz createQuiz() {
-        Quiz quiz = Quiz.createQuiz("quiz", User.createMember("n", "e", "p"));
+        Quiz quiz = Quiz.createQuiz("quiz", User.createMember("n", "e", null));
         Question question1 = Question.create(quiz, "question1");
         Answer.createAnswer(question1, "answer1");
         Question question2 = Question.create(quiz, "question2");

--- a/server/src/test/java/ppalatjyo/server/domain/game/GameTest.java
+++ b/server/src/test/java/ppalatjyo/server/domain/game/GameTest.java
@@ -23,7 +23,7 @@ class GameTest {
         // given
         User user = User.createGuest("user");
 
-        Quiz quiz = Quiz.createQuiz("quiz", User.createMember("n", "e", "p"));
+        Quiz quiz = Quiz.createQuiz("quiz", User.createMember("n", "e", null));
         Question question = Question.create(quiz, "question1");
         Answer.createAnswer(question, "answer1");
 
@@ -52,7 +52,7 @@ class GameTest {
         // given
         User user = User.createGuest("user");
 
-        Quiz quiz = Quiz.createQuiz("quiz", User.createMember("n", "e", "p"));
+        Quiz quiz = Quiz.createQuiz("quiz", User.createMember("n", "e", null));
         Question.create(quiz,"question1");
 
         Lobby lobby = Lobby.create("lobby", user, quiz, LobbyOptions.defaultOptions());
@@ -73,7 +73,7 @@ class GameTest {
         // given
         User user = User.createGuest("user");
 
-        Quiz quiz = Quiz.createQuiz("quiz", User.createMember("n", "e", "p"));
+        Quiz quiz = Quiz.createQuiz("quiz", User.createMember("n", "e", null));
         Question.create(quiz,"question1");
 
         Lobby lobby = Lobby.create("lobby", user, quiz, LobbyOptions.defaultOptions());
@@ -90,7 +90,7 @@ class GameTest {
     void hasNextQuestionTrue() {
         // given
         User user = User.createGuest("user");
-        Quiz quiz = Quiz.createQuiz("quiz", User.createMember("n", "e", "p"));
+        Quiz quiz = Quiz.createQuiz("quiz", User.createMember("n", "e", null));
         Question.create(quiz, "question1");
         Question.create(quiz, "question2");
         Lobby lobby = Lobby.create("lobby", user, quiz, LobbyOptions.defaultOptions());
@@ -107,7 +107,7 @@ class GameTest {
     void hasNextQuestionFalse() {
         // given
         User user = User.createGuest("user");
-        Quiz quiz = Quiz.createQuiz("quiz", User.createMember("n", "e", "p"));
+        Quiz quiz = Quiz.createQuiz("quiz", User.createMember("n", "e", null));
         Question.create(quiz, "question1");
         Lobby lobby = Lobby.create("lobby", user, quiz, LobbyOptions.defaultOptions());
 
@@ -124,7 +124,7 @@ class GameTest {
         // given
         User user = User.createGuest("user");
 
-        Quiz quiz = Quiz.createQuiz("quiz", User.createMember("n", "e", "p"));
+        Quiz quiz = Quiz.createQuiz("quiz", User.createMember("n", "e", null));
         Question.create(quiz,"question1");
         Question.create(quiz, "question2");
 
@@ -144,7 +144,7 @@ class GameTest {
         // given
         User user = User.createGuest("user");
 
-        Quiz quiz = Quiz.createQuiz("quiz", User.createMember("n", "e", "p"));
+        Quiz quiz = Quiz.createQuiz("quiz", User.createMember("n", "e", null));
         Question.create(quiz,"question1");
 
         Lobby lobby = Lobby.create("lobby", user, quiz, LobbyOptions.defaultOptions());

--- a/server/src/test/java/ppalatjyo/server/domain/lobby/LobbyServiceTest.java
+++ b/server/src/test/java/ppalatjyo/server/domain/lobby/LobbyServiceTest.java
@@ -46,7 +46,7 @@ class LobbyServiceTest {
         // given
         String name = "lobby";
         User host = User.createGuest("host");
-        Quiz quiz = Quiz.createQuiz("quiz", User.createMember("n", "e", "p"));
+        Quiz quiz = Quiz.createQuiz("quiz", User.createMember("n", "e", null));
         long hostId = 1L;
         long quizId = 1L;
         int maxUsers = 10;
@@ -79,7 +79,7 @@ class LobbyServiceTest {
         // given
         String name = "lobby";
         User host = User.createGuest("host");
-        Quiz quiz = Quiz.createQuiz("quiz", User.createMember("n", "e", "p"));
+        Quiz quiz = Quiz.createQuiz("quiz", User.createMember("n", "e", null));
         LobbyOptions options = LobbyOptions.createOptions(10, 10, 10);
         Lobby lobby = Lobby.create(name, host, quiz, options);
 
@@ -103,7 +103,7 @@ class LobbyServiceTest {
         // given
         String name = "lobby";
         User host = User.createGuest("host");
-        Quiz quiz = Quiz.createQuiz("quiz", User.createMember("n", "e", "p"));
+        Quiz quiz = Quiz.createQuiz("quiz", User.createMember("n", "e", null));
         LobbyOptions options = LobbyOptions.defaultOptions();
         Lobby lobby = Lobby.create(name, host, quiz, options);
 
@@ -122,7 +122,7 @@ class LobbyServiceTest {
     void deleteIfEmpty() {
         // given
         Long lobbyId = 1L;
-        Quiz quiz = Quiz.createQuiz("quiz", User.createMember("n", "e", "p"));
+        Quiz quiz = Quiz.createQuiz("quiz", User.createMember("n", "e", null));
         Lobby lobby = Lobby.create("lobby", User.createGuest("host"), quiz, LobbyOptions.defaultOptions());
         when(userLobbyRepository.countByLobbyIdAndLeftAtIsNull(lobbyId)).thenReturn(0);
         when(lobbyRepository.findById(lobbyId)).thenReturn(Optional.of(lobby));
@@ -142,7 +142,7 @@ class LobbyServiceTest {
         String name = "lobby";
         User oldHost = User.createGuest("oldHost");
         User newHost = User.createGuest("newHost");
-        Quiz quiz = Quiz.createQuiz("quiz", User.createMember("n", "e", "p"));
+        Quiz quiz = Quiz.createQuiz("quiz", User.createMember("n", "e", null));
         LobbyOptions options = LobbyOptions.defaultOptions();
         Lobby lobby = Lobby.create(name, oldHost, quiz, options);
 
@@ -162,8 +162,8 @@ class LobbyServiceTest {
     @DisplayName("Quiz 변경")
     void changeQuiz() {
         // given
-        Quiz oldQuiz = Quiz.createQuiz("oldQuiz", User.createMember("n", "e", "p"));
-        Quiz newQuiz = Quiz.createQuiz("newQuiz", User.createMember("n", "e", "p"));
+        Quiz oldQuiz = Quiz.createQuiz("oldQuiz", User.createMember("n", "e", null));
+        Quiz newQuiz = Quiz.createQuiz("newQuiz", User.createMember("n", "e", null));
         Lobby lobby = Lobby.create("lobby", User.createGuest("host"), oldQuiz, LobbyOptions.defaultOptions());
 
         long newQuizId = 1L;

--- a/server/src/test/java/ppalatjyo/server/domain/lobby/LobbyTest.java
+++ b/server/src/test/java/ppalatjyo/server/domain/lobby/LobbyTest.java
@@ -7,6 +7,7 @@ import ppalatjyo.server.domain.lobby.domain.LobbyOptions;
 import ppalatjyo.server.domain.lobby.domain.LobbyStatus;
 import ppalatjyo.server.domain.lobby.exception.LobbyAlreadyDeletedException;
 import ppalatjyo.server.domain.quiz.domain.Quiz;
+import ppalatjyo.server.domain.user.domain.OAuthProvider;
 import ppalatjyo.server.domain.user.domain.User;
 import ppalatjyo.server.domain.userlobby.UserLobby;
 
@@ -21,7 +22,7 @@ class LobbyTest {
         // given
         String name = "name";
         User host = User.createGuest("user");
-        Quiz quiz = Quiz.createQuiz("quiz", User.createMember("n", "e", "p"));
+        Quiz quiz = Quiz.createQuiz("quiz", User.createMember("n", "e", OAuthProvider.GITHUB));
         int maxUsers = 10;
         int minPerGame = 10;
         int secPerQuestion = 60;
@@ -49,7 +50,7 @@ class LobbyTest {
         String name = "name";
         String password = "1234";
         User host = User.createGuest("user");
-        Quiz quiz = Quiz.createQuiz("quiz", User.createMember("n", "e", "p"));
+        Quiz quiz = Quiz.createQuiz("quiz", User.createMember("n", "e", OAuthProvider.GITHUB));
         int maxUsers = 10;
         int minPerGame = 10;
         int secPerQuestion = 60;
@@ -80,7 +81,7 @@ class LobbyTest {
         // given
         String oldName = "oldName";
         String newName = "newName";
-        Lobby lobby = Lobby.create(oldName, User.createGuest("host"), Quiz.createQuiz("quiz", User.createMember("n", "e", "p")), LobbyOptions.defaultOptions());
+        Lobby lobby = Lobby.create(oldName, User.createGuest("host"), Quiz.createQuiz("quiz", User.createMember("n", "e", OAuthProvider.GITHUB)), LobbyOptions.defaultOptions());
 
         // when
         lobby.changeName(newName);
@@ -93,7 +94,7 @@ class LobbyTest {
     @DisplayName("Lobby 삭제")
     void deleteLobby() {
         // given
-        Lobby lobby = Lobby.create("lobby", User.createGuest("host"), Quiz.createQuiz("quiz", User.createMember("n", "e", "p")), LobbyOptions.defaultOptions());
+        Lobby lobby = Lobby.create("lobby", User.createGuest("host"), Quiz.createQuiz("quiz", User.createMember("n", "e", OAuthProvider.GITHUB)), LobbyOptions.defaultOptions());
 
         // when
         lobby.delete();
@@ -107,7 +108,7 @@ class LobbyTest {
     @DisplayName("삭제된 Lobby는 삭제할 수 없음")
     void lobbyAlreadyDeleted() {
         // given
-        Lobby lobby = Lobby.create("lobby", User.createGuest("host"), Quiz.createQuiz("quiz", User.createMember("n", "e", "p")), LobbyOptions.defaultOptions());
+        Lobby lobby = Lobby.create("lobby", User.createGuest("host"), Quiz.createQuiz("quiz", User.createMember("n", "e", OAuthProvider.GITHUB)), LobbyOptions.defaultOptions());
         lobby.delete();
 
         // when
@@ -122,7 +123,7 @@ class LobbyTest {
         User oldHost = User.createGuest("oldHost");
         User newHost = User.createGuest("newHost");
 
-        Lobby lobby = Lobby.create("lobby", oldHost, Quiz.createQuiz("quiz", User.createMember("n", "e", "p")), LobbyOptions.defaultOptions());
+        Lobby lobby = Lobby.create("lobby", oldHost, Quiz.createQuiz("quiz", User.createMember("n", "e", OAuthProvider.GITHUB)), LobbyOptions.defaultOptions());
 
         // when
         lobby.changeHost(newHost);
@@ -136,7 +137,7 @@ class LobbyTest {
     void changeOptions() {
         // given
         LobbyOptions options = LobbyOptions.createOptions(10, 10, 10);
-        Lobby lobby = Lobby.create("lobby", User.createGuest("host"), Quiz.createQuiz("quiz", User.createMember("n", "e", "p")), options);
+        Lobby lobby = Lobby.create("lobby", User.createGuest("host"), Quiz.createQuiz("quiz", User.createMember("n", "e", OAuthProvider.GITHUB)), options);
         LobbyOptions newOptions = LobbyOptions.createOptions(20, 20, 20);
 
         // when
@@ -152,10 +153,10 @@ class LobbyTest {
     @DisplayName("Quiz 변경")
     void changeQuiz() {
         // given
-        Quiz oldQuiz = Quiz.createQuiz("oldQuiz", User.createMember("n", "e", "p"));
+        Quiz oldQuiz = Quiz.createQuiz("oldQuiz", User.createMember("n", "e", OAuthProvider.GITHUB));
         Lobby lobby = Lobby.create("lobby", User.createGuest("host"), oldQuiz, LobbyOptions.defaultOptions());
 
-        Quiz newQuiz = Quiz.createQuiz("newQuiz", User.createMember("n", "e", "p"));
+        Quiz newQuiz = Quiz.createQuiz("newQuiz", User.createMember("n", "e", OAuthProvider.GITHUB));
 
         // when
         lobby.changeQuiz(newQuiz);
@@ -168,7 +169,7 @@ class LobbyTest {
     @DisplayName("로비가 비었으면 isEmpty() == true")
     void isEmpty() {
         // given
-        Quiz quiz = Quiz.createQuiz("oldQuiz", User.createMember("n", "e", "p"));
+        Quiz quiz = Quiz.createQuiz("oldQuiz", User.createMember("n", "e", OAuthProvider.GITHUB));
         User user = User.createGuest("host");
         Lobby lobby = Lobby.create("lobby", user, quiz, LobbyOptions.defaultOptions());
 
@@ -185,7 +186,7 @@ class LobbyTest {
     @DisplayName("로비에 누가 남아있으면 isEmpty() == false")
     void isEmptyFalse() {
         // given
-        Quiz quiz = Quiz.createQuiz("oldQuiz", User.createMember("n", "e", "p"));
+        Quiz quiz = Quiz.createQuiz("oldQuiz", User.createMember("n", "e", OAuthProvider.GITHUB));
         User user = User.createGuest("host");
         Lobby lobby = Lobby.create("lobby", user, quiz, LobbyOptions.defaultOptions());
 

--- a/server/src/test/java/ppalatjyo/server/domain/message/MessageTest.java
+++ b/server/src/test/java/ppalatjyo/server/domain/message/MessageTest.java
@@ -72,7 +72,7 @@ class MessageTest {
     }
 
     private Quiz getQuiz() {
-        Quiz quiz = Quiz.createQuiz("quiz", User.createMember("n", "e", "p"));
+        Quiz quiz = Quiz.createQuiz("quiz", User.createMember("n", "e", null));
         Question question1 = Question.create(quiz, "question1");
         Answer.createAnswer(question1, "answer1");
         Question question2 = Question.create(quiz, "question2");

--- a/server/src/test/java/ppalatjyo/server/domain/quiz/AnswerServiceTest.java
+++ b/server/src/test/java/ppalatjyo/server/domain/quiz/AnswerServiceTest.java
@@ -36,7 +36,7 @@ class AnswerServiceTest {
     @DisplayName("정답 추가")
     void addAnswer() {
         // given
-        User user = User.createMember("user", "", "");
+        User user = User.createMember("user", "", null);
         Quiz quiz = Quiz.createQuiz("quiz", user);
         Question question = Question.create(quiz, "question");
 
@@ -65,7 +65,7 @@ class AnswerServiceTest {
     @DisplayName("정답 수정")
     void updateAnswer() {
         // given
-        User user = User.createMember("user", "", "");
+        User user = User.createMember("user", "", null);
         Quiz quiz = Quiz.createQuiz("quiz", user);
         Question question = Question.create(quiz, "question");
         Answer answer = Answer.createAnswer(question, "answer");
@@ -89,7 +89,7 @@ class AnswerServiceTest {
     @DisplayName("정답 삭제")
     void deleteAnswer() {
         // given
-        User user = User.createMember("user", "", "");
+        User user = User.createMember("user", "", null);
         Quiz quiz = Quiz.createQuiz("quiz", user);
         Question question = Question.create(quiz, "question");
         Answer answer = Answer.createAnswer(question, "answer");

--- a/server/src/test/java/ppalatjyo/server/domain/quiz/QuestionServiceTest.java
+++ b/server/src/test/java/ppalatjyo/server/domain/quiz/QuestionServiceTest.java
@@ -38,7 +38,7 @@ class QuestionServiceTest {
     @DisplayName("Question 생성, Quiz에 추가")
     void createQuestion() {
         // given
-        User member = User.createMember("user", "", "");
+        User member = User.createMember("user", "", null);
         Quiz quiz = Quiz.createQuiz("title", member);
 
         Long quizId = 1L;
@@ -66,7 +66,7 @@ class QuestionServiceTest {
     @DisplayName("Question 수정")
     void updateQuestion() {
         // given
-        User member = User.createMember("user", "", "");
+        User member = User.createMember("user", "", null);
         Quiz quiz = Quiz.createQuiz("title", member);
         Question question = Question.create(quiz, "content");
         Long questionId = 1L;
@@ -88,7 +88,7 @@ class QuestionServiceTest {
     @DisplayName("Question 삭제")
     void delete() {
         // given
-        User member = User.createMember("user", "", "");
+        User member = User.createMember("user", "", null);
         Quiz quiz = Quiz.createQuiz("title", member);
         Question question = Question.create(quiz, "content");
         Long questionId = 1L;

--- a/server/src/test/java/ppalatjyo/server/domain/quiz/QuizServiceTest.java
+++ b/server/src/test/java/ppalatjyo/server/domain/quiz/QuizServiceTest.java
@@ -8,7 +8,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.transaction.annotation.Transactional;
-import ppalatjyo.server.domain.quiz.QuizService;
 import ppalatjyo.server.domain.quiz.domain.Quiz;
 import ppalatjyo.server.domain.quiz.domain.QuizVisibility;
 import ppalatjyo.server.domain.quiz.dto.CreateQuizRequestDto;
@@ -41,7 +40,7 @@ class QuizServiceTest {
         String title = "quiz";
         String description = "quiz description";
         QuizVisibility visibility = QuizVisibility.PUBLIC;
-        User member = User.createMember("user", "", "");
+        User member = User.createMember("user", "", null);
 
         Long userId = 1L;
 
@@ -65,7 +64,7 @@ class QuizServiceTest {
     @DisplayName("Quiz 이름 수정")
     void changeTitle() {
         // given
-        User member = User.createMember("user", "", "");
+        User member = User.createMember("user", "", null);
         Quiz quiz = Quiz.createQuiz("title", member);
 
         Long quizId = 1L;
@@ -84,7 +83,7 @@ class QuizServiceTest {
     @DisplayName("Quiz 삭제")
     void delete() {
         // given
-        User member = User.createMember("user", "", "");
+        User member = User.createMember("user", "", null);
         Quiz quiz = Quiz.createQuiz("title", member);
 
         Long quizId = 1L;

--- a/server/src/test/java/ppalatjyo/server/domain/quiz/domain/AnswerTest.java
+++ b/server/src/test/java/ppalatjyo/server/domain/quiz/domain/AnswerTest.java
@@ -2,9 +2,6 @@ package ppalatjyo.server.domain.quiz.domain;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import ppalatjyo.server.domain.quiz.domain.Answer;
-import ppalatjyo.server.domain.quiz.domain.Question;
-import ppalatjyo.server.domain.quiz.domain.Quiz;
 import ppalatjyo.server.domain.user.domain.User;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -15,7 +12,7 @@ class AnswerTest {
     @DisplayName("Answer 생성")
     void createAnswer() {
         // given
-        User member = User.createMember("user", "", "");
+        User member = User.createMember("user", "", null);
         Quiz quiz = Quiz.createQuiz("quiz", member);
         String content = "answer";
         Question question = Question.create(quiz, "question");
@@ -34,7 +31,7 @@ class AnswerTest {
     @DisplayName("content 변경")
     void changeContent() {
         // given
-        User member = User.createMember("user", "", "");
+        User member = User.createMember("user", "", null);
         Quiz quiz = Quiz.createQuiz("quiz", member);
         String content = "answer";
         Question question = Question.create(quiz, "question");
@@ -53,7 +50,7 @@ class AnswerTest {
     @DisplayName("Answer 삭제")
     void delete() {
         // given
-        User member = User.createMember("user", "", "");
+        User member = User.createMember("user", "", null);
         Quiz quiz = Quiz.createQuiz("quiz", member);
         String content = "answer";
         Question question = Question.create(quiz, "question");
@@ -70,7 +67,7 @@ class AnswerTest {
     @DisplayName("정답 확인 - 정답")
     void isCorrect() {
         // given
-        User member = User.createMember("user", "", "");
+        User member = User.createMember("user", "", null);
         Quiz quiz = Quiz.createQuiz("quiz", member);
         String content = "answer";
         Question question = Question.create(quiz, "question");
@@ -87,7 +84,7 @@ class AnswerTest {
     @DisplayName("정답 확인 - 오답")
     void isCorrectFalse() {
         // given
-        User member = User.createMember("user", "", "");
+        User member = User.createMember("user", "", null);
         Quiz quiz = Quiz.createQuiz("quiz", member);
         String content = "answer";
         Question question = Question.create(quiz, "question");

--- a/server/src/test/java/ppalatjyo/server/domain/quiz/domain/QuestionTest.java
+++ b/server/src/test/java/ppalatjyo/server/domain/quiz/domain/QuestionTest.java
@@ -16,7 +16,7 @@ class QuestionTest {
     void create() {
         // given
         String content = "content";
-        User user = User.createMember("author", "<EMAIL>", "google");
+        User user = User.createMember("author", "<EMAIL>", null);
         Quiz quiz = Quiz.createQuiz("quiz", user);
 
         // when
@@ -32,7 +32,7 @@ class QuestionTest {
     @DisplayName("content 변경")
     void changeContent() {
         // given
-        User user = User.createMember("author", "<EMAIL>", "google");
+        User user = User.createMember("author", "<EMAIL>", null);
         Quiz quiz = Quiz.createQuiz("quiz", user);
         Question question = Question.create(quiz, "content");
 
@@ -49,7 +49,7 @@ class QuestionTest {
     @DisplayName("Question 삭제")
     void delete() {
         // given
-        User user = User.createMember("author", "<EMAIL>", "google");
+        User user = User.createMember("author", "<EMAIL>", null);
         Quiz quiz = Quiz.createQuiz("quiz", user);
         Question question = Question.create(quiz, "content");
 
@@ -64,7 +64,7 @@ class QuestionTest {
     @DisplayName("정답 확인 - 정답")
     void isCorrect() {
         // given
-        User user = User.createMember("author", "<EMAIL>", "google");
+        User user = User.createMember("author", "<EMAIL>", null);
         Quiz quiz = Quiz.createQuiz("quiz", user);
         Question question = Question.create(quiz, "question");
 
@@ -82,7 +82,7 @@ class QuestionTest {
     @DisplayName("정답 확인 - 오답")
     void isCorrectFalse() {
         // given
-        User user = User.createMember("author", "<EMAIL>", "google");
+        User user = User.createMember("author", "<EMAIL>", null);
         Quiz quiz = Quiz.createQuiz("quiz", user);
         Question question = Question.create(quiz, "question");
 

--- a/server/src/test/java/ppalatjyo/server/domain/quiz/domain/QuizTest.java
+++ b/server/src/test/java/ppalatjyo/server/domain/quiz/domain/QuizTest.java
@@ -20,7 +20,7 @@ class QuizTest {
     void createQuiz() {
         // given
         String name = "quiz";
-        User member = User.createMember("author", "test@email.com", "google");
+        User member = User.createMember("author", "test@email.com", null);
         String description = "description";
         QuizVisibility visibility = QuizVisibility.PUBLIC;
 
@@ -51,7 +51,7 @@ class QuizTest {
     @DisplayName("Quiz 이름 수정")
     void changeTitle() {
         // given
-        Quiz quiz = Quiz.createQuiz("oldName", User.createMember("n", "e", "p"));
+        Quiz quiz = Quiz.createQuiz("oldName", User.createMember("n", "e", null));
         String name = "newName";
 
         // when
@@ -65,7 +65,7 @@ class QuizTest {
     @DisplayName("문제 추가")
     void addQuestion() {
         // given
-        Quiz quiz = Quiz.createQuiz("quiz", User.createMember("n", "e", "p"));
+        Quiz quiz = Quiz.createQuiz("quiz", User.createMember("n", "e", null));
         Question question = Question.create(quiz, "content");
         Answer.createAnswer(question, "answer1");
         Answer.createAnswer(question, "answer2");
@@ -85,7 +85,7 @@ class QuizTest {
     @DisplayName("문제 삭제")
     void delete() {
         // given
-        Quiz quiz = Quiz.createQuiz("quiz", User.createMember("n", "e", "p"));
+        Quiz quiz = Quiz.createQuiz("quiz", User.createMember("n", "e", null));
 
         // when
         quiz.delete();

--- a/server/src/test/java/ppalatjyo/server/domain/user/UserServiceTest.java
+++ b/server/src/test/java/ppalatjyo/server/domain/user/UserServiceTest.java
@@ -9,6 +9,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.transaction.annotation.Transactional;
 import ppalatjyo.server.domain.user.UserRepository;
 import ppalatjyo.server.domain.user.UserService;
+import ppalatjyo.server.domain.user.domain.OAuthProvider;
 import ppalatjyo.server.domain.user.domain.User;
 import ppalatjyo.server.domain.user.domain.UserRole;
 import ppalatjyo.server.domain.user.dto.JoinAsMemberResponseDto;
@@ -55,7 +56,7 @@ class UserServiceTest {
         // given
         String nickname = "nickname";
         String oAuthEmail = "test@test.com";
-        String oAuthProvider = "github";
+        OAuthProvider oAuthProvider = OAuthProvider.GITHUB;
 
         // when
         JoinAsMemberResponseDto responseDto = userService.joinAsMember(nickname, oAuthEmail, oAuthProvider);
@@ -73,7 +74,7 @@ class UserServiceTest {
         User user = User.createGuest("nickname");
         Long id = 1L;
         String oAuthEmail = "test@test.com";
-        String oAuthProvider = "github";
+        OAuthProvider oAuthProvider = OAuthProvider.GITHUB;
         when(userRepository.findById(id)).thenReturn(Optional.of(user));
 
         // when

--- a/server/src/test/java/ppalatjyo/server/domain/user/UserServiceTest.java
+++ b/server/src/test/java/ppalatjyo/server/domain/user/UserServiceTest.java
@@ -58,13 +58,16 @@ class UserServiceTest {
         String oAuthEmail = "test@test.com";
         OAuthProvider oAuthProvider = OAuthProvider.GITHUB;
 
+        User saved = mock(User.class);
+        when(userRepository.save(any(User.class))).thenReturn(saved);
+        when(saved.getId()).thenReturn(1L);
+
         // when
-        JoinAsMemberResponseDto responseDto = userService.joinAsMember(nickname, oAuthEmail, oAuthProvider);
+        long userId = userService.joinAsMember(nickname, oAuthEmail, oAuthProvider);
 
         // then
-        assertThat(responseDto.getAccessToken()).isNotNull();
-        assertThat(responseDto.getRefreshToken()).isNotNull();
-        // TODO: 2025-06-02 Token 검증 추가
+        assertThat(userId).isEqualTo(1L);
+        verify(userRepository).save(any(User.class));
     }
 
     @Test

--- a/server/src/test/java/ppalatjyo/server/domain/user/UserTest.java
+++ b/server/src/test/java/ppalatjyo/server/domain/user/UserTest.java
@@ -2,6 +2,7 @@ package ppalatjyo.server.domain.user;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import ppalatjyo.server.domain.user.domain.OAuthProvider;
 import ppalatjyo.server.domain.user.exception.UserAlreadyMemberException;
 import ppalatjyo.server.domain.user.domain.User;
 import ppalatjyo.server.domain.user.domain.UserRole;
@@ -35,7 +36,7 @@ class UserTest {
         // given
         String nickname = "nickname";
         String oAuthEmail = "member@test.com";
-        String oAuthProvider = "provider";
+        OAuthProvider oAuthProvider = OAuthProvider.GITHUB;
 
         // when
         User user = User.createMember(nickname, oAuthEmail, oAuthProvider);
@@ -58,7 +59,7 @@ class UserTest {
         User user = User.createGuest(nickname);
 
         String oAuthEmail = "member@test.com";
-        String oAuthProvider = "provider";
+        OAuthProvider oAuthProvider = OAuthProvider.GITHUB;
 
         // when
         user.promoteGuestToMember(oAuthEmail, oAuthProvider);
@@ -75,7 +76,7 @@ class UserTest {
         // given
         String nickname = "nickname";
         String oAuthEmail = "member@test.com";
-        String oAuthProvider = "provider";
+        OAuthProvider oAuthProvider = OAuthProvider.GITHUB;
 
         User user = User.createMember(nickname, oAuthEmail, oAuthProvider);
 

--- a/server/src/test/java/ppalatjyo/server/domain/usergame/UserGameServiceTest.java
+++ b/server/src/test/java/ppalatjyo/server/domain/usergame/UserGameServiceTest.java
@@ -32,7 +32,7 @@ class UserGameServiceTest {
     void increaseScoreBy() {
         // given
         User user = User.createGuest("user");
-        Quiz quiz = Quiz.createQuiz("quiz", User.createMember("m", "email", "password"));
+        Quiz quiz = Quiz.createQuiz("quiz", User.createMember("m", "email", null));
         Lobby lobby = Lobby.create(
                 "lobby",
                 user,

--- a/server/src/test/java/ppalatjyo/server/domain/usergame/UserGameTest.java
+++ b/server/src/test/java/ppalatjyo/server/domain/usergame/UserGameTest.java
@@ -48,7 +48,7 @@ class UserGameTest {
     }
 
     private Quiz getQuiz() {
-        Quiz quiz = Quiz.createQuiz("quiz", User.createMember("n", "e", "p"));
+        Quiz quiz = Quiz.createQuiz("quiz", User.createMember("n", "e", null));
         Question question1 = Question.create(quiz, "question1");
         Answer.createAnswer(question1, "answer1");
         Question question2 = Question.create(quiz, "question2");

--- a/server/src/test/java/ppalatjyo/server/domain/userlobby/UserLobbyServiceTest.java
+++ b/server/src/test/java/ppalatjyo/server/domain/userlobby/UserLobbyServiceTest.java
@@ -49,7 +49,7 @@ class UserLobbyServiceTest {
         Long userId = 1L;
         Long lobbyId = 1L;
 
-        User host = User.createMember("host", "email", "provider");
+        User host = User.createMember("host", "email", null);
         Lobby lobby = Lobby.create("lobby", host, Quiz.createQuiz("quiz", host), LobbyOptions.defaultOptions());
         User user = User.createGuest("user");
 
@@ -80,7 +80,7 @@ class UserLobbyServiceTest {
         Long userId = 1L;
         Long lobbyId = 1L;
 
-        User host = User.createMember("host", "email", "provider");
+        User host = User.createMember("host", "email", null);
         Lobby lobby = Lobby.create("lobby", host, Quiz.createQuiz("quiz", host), LobbyOptions.defaultOptions());
         Question.create(lobby.getQuiz(), "question");
         User user = User.createGuest("user");
@@ -106,7 +106,7 @@ class UserLobbyServiceTest {
         int maxUsers = 10;
         LobbyOptions options = LobbyOptions.createOptions(maxUsers, 10, 10);
 
-        User host = User.createMember("host", "email", "provider");
+        User host = User.createMember("host", "email", null);
         Lobby lobby = Lobby.create("lobby", host, Quiz.createQuiz("quiz", host), options);
         User user = User.createGuest("user");
 
@@ -130,7 +130,7 @@ class UserLobbyServiceTest {
         Long userId = 1L;
         Long lobbyId = 1L;
 
-        User host = User.createMember("host", "email", "provider");
+        User host = User.createMember("host", "email", null);
         Lobby lobby = Lobby.withPassword("lobby", password, host, Quiz.createQuiz("quiz", host), LobbyOptions.defaultOptions());
         User user = User.createGuest("user");
 
@@ -162,7 +162,7 @@ class UserLobbyServiceTest {
         Long userId = 1L;
         Long lobbyId = 1L;
 
-        User host = User.createMember("host", "email", "provider");
+        User host = User.createMember("host", "email", null);
         Lobby lobby = Lobby.withPassword("lobby", password, host, Quiz.createQuiz("quiz", host), LobbyOptions.defaultOptions());
         User user = User.createGuest("user");
 
@@ -182,7 +182,7 @@ class UserLobbyServiceTest {
         Long userId = 1L;
         Long lobbyId = 1L;
 
-        User host = User.createMember("host", "email", "provider");
+        User host = User.createMember("host", "email", null);
         Lobby lobby = Lobby.create("lobby", host, Quiz.createQuiz("quiz", host), LobbyOptions.defaultOptions());
         User user = User.createGuest("user");
 

--- a/server/src/test/java/ppalatjyo/server/global/auth/AuthServiceTest.java
+++ b/server/src/test/java/ppalatjyo/server/global/auth/AuthServiceTest.java
@@ -10,8 +10,11 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import ppalatjyo.server.domain.user.domain.OAuthProvider;
 import ppalatjyo.server.global.auth.domain.RefreshToken;
 import ppalatjyo.server.global.auth.dto.JoinAsGuestResponseDto;
+import ppalatjyo.server.global.auth.dto.JoinAsMemberByGitHubRequestDto;
+import ppalatjyo.server.global.auth.dto.JoinAsMemberByGitHubResponseDto;
 import ppalatjyo.server.global.auth.dto.TokenReissueResponseDto;
 import ppalatjyo.server.global.auth.repository.RefreshTokenRepository;
 import ppalatjyo.server.global.security.jwt.JwtTokenProvider;
@@ -91,8 +94,24 @@ class AuthServiceTest {
     @Test
     @DisplayName("멤버로 가입 - GitHub")
     void joinAsMemberByGitHub() {
+        // given
         String nickname = "nickname";
+        String code = "code";
         HttpServletResponse response = mock(HttpServletResponse.class);
 
+        JoinAsMemberByGitHubRequestDto requestDto = new JoinAsMemberByGitHubRequestDto();
+        requestDto.setNickname(nickname);
+        requestDto.setCode(code);
+
+        when(jwtTokenProvider.createAccessToken(anyLong())).thenReturn("accessToken");
+        when(jwtTokenProvider.createRefreshToken(anyLong())).thenReturn("refreshToken");
+
+        // when
+        JoinAsMemberByGitHubResponseDto responseDto = authService.joinAsMemberByGitHub(requestDto, response);
+
+        // then
+        verify(userService).joinAsMember(nickname, anyString(), OAuthProvider.GITHUB);
+        verify(refreshTokenRepository).save(any(RefreshToken.class));
+        assertThat(responseDto.getAccessToken()).isNotNull();
     }
 }

--- a/server/src/test/java/ppalatjyo/server/global/auth/AuthServiceTest.java
+++ b/server/src/test/java/ppalatjyo/server/global/auth/AuthServiceTest.java
@@ -17,6 +17,7 @@ import ppalatjyo.server.global.auth.dto.JoinAsMemberByGitHubRequestDto;
 import ppalatjyo.server.global.auth.dto.JoinAsMemberByGitHubResponseDto;
 import ppalatjyo.server.global.auth.dto.TokenReissueResponseDto;
 import ppalatjyo.server.global.auth.repository.RefreshTokenRepository;
+import ppalatjyo.server.global.auth.service.AuthService;
 import ppalatjyo.server.global.security.jwt.JwtTokenProvider;
 import ppalatjyo.server.domain.user.UserRepository;
 import ppalatjyo.server.domain.user.UserService;

--- a/server/src/test/java/ppalatjyo/server/global/auth/AuthServiceTest.java
+++ b/server/src/test/java/ppalatjyo/server/global/auth/AuthServiceTest.java
@@ -110,7 +110,7 @@ class AuthServiceTest {
         JoinAsMemberByGitHubResponseDto responseDto = authService.joinAsMemberByGitHub(requestDto, response);
 
         // then
-        verify(userService).joinAsMember(nickname, anyString(), OAuthProvider.GITHUB);
+        verify(userService).joinAsMember(eq(nickname), anyString(), eq(OAuthProvider.GITHUB));
         verify(refreshTokenRepository).save(any(RefreshToken.class));
         assertThat(responseDto.getAccessToken()).isNotNull();
     }

--- a/server/src/test/java/ppalatjyo/server/global/auth/AuthServiceTest.java
+++ b/server/src/test/java/ppalatjyo/server/global/auth/AuthServiceTest.java
@@ -11,7 +11,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import ppalatjyo.server.global.auth.domain.RefreshToken;
-import ppalatjyo.server.global.auth.dto.SignUpAsGuestResponseDto;
+import ppalatjyo.server.global.auth.dto.JoinAsGuestResponseDto;
 import ppalatjyo.server.global.auth.dto.TokenReissueResponseDto;
 import ppalatjyo.server.global.auth.repository.RefreshTokenRepository;
 import ppalatjyo.server.global.security.jwt.JwtTokenProvider;
@@ -50,7 +50,7 @@ class AuthServiceTest {
         when(jwtTokenProvider.createAccessToken(anyLong())).thenReturn("accessToken");
 
         // when
-        SignUpAsGuestResponseDto responseDto = authService.singUpAsGuest(nickname, response);
+        JoinAsGuestResponseDto responseDto = authService.joinAsGuest(nickname, response);
 
         // then
         verify(userService).joinAsGuest(nickname);
@@ -86,5 +86,13 @@ class AuthServiceTest {
         verify(response).addCookie(any(Cookie.class));
 
         assertThat(responseDto.getAccessToken()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("멤버로 가입 - GitHub")
+    void joinAsMemberByGitHub() {
+        String nickname = "nickname";
+        HttpServletResponse response = mock(HttpServletResponse.class);
+
     }
 }

--- a/server/src/test/java/ppalatjyo/server/global/auth/AuthServiceTest.java
+++ b/server/src/test/java/ppalatjyo/server/global/auth/AuthServiceTest.java
@@ -10,6 +10,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import ppalatjyo.server.domain.user.UserRepository;
+import ppalatjyo.server.domain.user.UserService;
 import ppalatjyo.server.domain.user.domain.OAuthProvider;
 import ppalatjyo.server.global.auth.domain.RefreshToken;
 import ppalatjyo.server.global.auth.dto.JoinAsGuestResponseDto;
@@ -18,9 +20,8 @@ import ppalatjyo.server.global.auth.dto.JoinAsMemberByGitHubResponseDto;
 import ppalatjyo.server.global.auth.dto.TokenReissueResponseDto;
 import ppalatjyo.server.global.auth.repository.RefreshTokenRepository;
 import ppalatjyo.server.global.auth.service.AuthService;
+import ppalatjyo.server.global.auth.service.GitHubOAuthService;
 import ppalatjyo.server.global.security.jwt.JwtTokenProvider;
-import ppalatjyo.server.domain.user.UserRepository;
-import ppalatjyo.server.domain.user.UserService;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.*;
@@ -40,6 +41,9 @@ class AuthServiceTest {
 
     @Mock
     private UserRepository userRepository;
+
+    @Mock
+    private GitHubOAuthService gitHubOAuthService;
 
     @InjectMocks
     private AuthService authService;
@@ -98,6 +102,7 @@ class AuthServiceTest {
         // given
         String nickname = "nickname";
         String code = "code";
+        String email = "email";
         HttpServletResponse response = mock(HttpServletResponse.class);
 
         JoinAsMemberByGitHubRequestDto requestDto = new JoinAsMemberByGitHubRequestDto();
@@ -106,12 +111,13 @@ class AuthServiceTest {
 
         when(jwtTokenProvider.createAccessToken(anyLong())).thenReturn("accessToken");
         when(jwtTokenProvider.createRefreshToken(anyLong())).thenReturn("refreshToken");
+        when(gitHubOAuthService.getEmailFromCode(code)).thenReturn(email);
 
         // when
         JoinAsMemberByGitHubResponseDto responseDto = authService.joinAsMemberByGitHub(requestDto, response);
 
         // then
-        verify(userService).joinAsMember(eq(nickname), anyString(), eq(OAuthProvider.GITHUB));
+        verify(userService).joinAsMember(nickname, email, OAuthProvider.GITHUB);
         verify(refreshTokenRepository).save(any(RefreshToken.class));
         assertThat(responseDto.getAccessToken()).isNotNull();
     }


### PR DESCRIPTION
## 관련 이슈

- #120

## 변경 사항

- GitHub을 통한 OAuth 가입을 위해 `GitHubOAuthService`를 추가하였습니다.
  - `GitHubOAuthService`는 환경 변수로 `client-id`와 `client-secret`을 주입 받습니다.
  - `getEmailByCode()` 메서드를 제공합니다.
- `AuthService`에 `joinAsMemberByGitHub()`를 추가하였습니다.
  - 유저로부터 `code`를 받아서 이를 통해 이메일을 요청하고 해당 이메일로 멤버 엔티티를 생성합니다.
  - 성공하면 엑세스 토큰을 반환합니다.
- 관련 테스트를 수정하였습니다.

## 고려 사항 및 주의 사항 (선택)

- 로그인을 이후 해당 url로 통일합니다. 만약 이미 깃허브로 가입되어 있다면 로그인 처리를 하도록 수정합니다.

## 추가 정보 (선택)
