### PR TITLE
[FEATURE]: 사용자 권한(Role)에 따른 인가 처리 구현 #149

### DIFF
--- a/server/src/main/java/ppalatjyo/server/global/security/SecurityConfig.java
+++ b/server/src/main/java/ppalatjyo/server/global/security/SecurityConfig.java
@@ -6,6 +6,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.ProviderManager;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -19,6 +20,7 @@ import ppalatjyo.server.global.security.jwt.JwtAuthenticationProvider;
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
 

--- a/server/src/main/java/ppalatjyo/server/global/security/SecurityTestController.java
+++ b/server/src/main/java/ppalatjyo/server/global/security/SecurityTestController.java
@@ -1,0 +1,40 @@
+package ppalatjyo.server.global.security;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/test")
+@Slf4j
+public class SecurityTestController {
+
+    @GetMapping("/anonymous")
+    public ResponseEntity<String> anonymous(Authentication authentication) {
+        logAuthentication(authentication);
+        return ResponseEntity.ok().build();
+    }
+
+    @PreAuthorize("hasRole('GUEST')")
+    @GetMapping("/guest")
+    public ResponseEntity<String> guest(Authentication authentication) {
+        logAuthentication(authentication);
+        return ResponseEntity.ok().build();
+    }
+
+    // Method Security에 의한 AccessDeniedException은 AuthorizationFilter가 아닌 Controller 에서 던져짐
+    @PreAuthorize("hasRole('MEMBER')")
+    @GetMapping("/member")
+    public ResponseEntity<String> member(Authentication authentication) {
+        logAuthentication(authentication);
+        return ResponseEntity.ok().build();
+    }
+
+    private void logAuthentication(Authentication authentication) {
+        log.info("Authentication object: {}", authentication);
+    }
+}

--- a/server/src/main/java/ppalatjyo/server/global/security/userdetails/CustomUserDetails.java
+++ b/server/src/main/java/ppalatjyo/server/global/security/userdetails/CustomUserDetails.java
@@ -1,9 +1,9 @@
 package ppalatjyo.server.global.security.userdetails;
 
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import ppalatjyo.server.domain.user.domain.User;
-import ppalatjyo.server.domain.user.domain.UserRole;
 
 import java.util.Collection;
 import java.util.List;
@@ -20,13 +20,11 @@ public class CustomUserDetails implements UserDetails {
         return user.getId();
     }
 
-    public UserRole getRole() {
-        return user.getRole();
-    }
-
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return List.of();
+        return List.of(
+                new SimpleGrantedAuthority("ROLE_" + user.getRole().name())
+        );
     }
 
     @Override


### PR DESCRIPTION
## 관련 이슈

- #149

## 변경 사항

- `CustomUserDetails`에서 `getAuthorities()` 메서드를 구현하였습니다.
  - `user.role`을 통해 `SimpleGrantedAuthority` 리스트를 반환하도록 구현하였습니다.
  ```java
  @Override
  public Collection<? extends GrantedAuthority> getAuthorities() {
      return List.of(
              new SimpleGrantedAuthority("ROLE_" + user.getRole().name())
      );
  }
  ```
- 각 권한 별 인가 처리 테스트를 위해 테스트 컨트롤러를 작성하였습니다.
- `SecurityConfig`에 `@EnableMethodSecurity`를 추가하였습니다.

## 테스트

- 아래는 GUEST 유저로 접근 시 볼 수 있는 인증 객체 정보입니다.

```
2025-07-07T23:58:25.141+09:00 TRACE 30868 --- [nio-8080-exec-3] o.s.s.w.a.AnonymousAuthenticationFilter  : Did not set SecurityContextHolder since already authenticated JwtAuthenticationToken [Principal=ppalatjyo.server.global.security.userdetails.CustomUserDetails@6476f075, Credentials=[PROTECTED], Authenticated=true, Details=null, Granted Authorities=[ROLE_GUEST]]
```

## 고려 사항 및 주의 사항 (선택)

## 추가 정보 (선택)

- Method Security의 `@PreAuthorize` 등을 통해 발생하는 `AccessDeniedException`은 `AuthorizationFilter`가 아닌 컨트롤러에서 발생한다는 사실을 배웠습니다. 따라서 Method Security로 인해 발생하는 예외는 `RestControllerAdvice` 등으로 처리해야 합니다.
