### PR TITLE
[FEATURE]: 멤버로 전환 페이지 구현 #136

### DIFF
--- a/client/src/page/profile/ProfilePage.tsx
+++ b/client/src/page/profile/ProfilePage.tsx
@@ -27,6 +27,12 @@ export default function ProfilePage() {
             <Button aria-label="log-out" onPress={() => navigate("/logout")}>
                 로그아웃
             </Button>
+            <Button
+                data-testid="to-member-button"
+                onPress={() => navigate("/profile/to-member")}
+            >
+                멤버로 전환
+            </Button>
         </div>
     );
 }

--- a/client/src/page/profile/ToMemberPage.tsx
+++ b/client/src/page/profile/ToMemberPage.tsx
@@ -1,0 +1,9 @@
+import GitHubLogInButton from "../../components/GitHubLogInButton";
+
+export default function ToMemberPage() {
+    return (
+        <div>
+            <GitHubLogInButton />
+        </div>
+    );
+}

--- a/client/src/test/page/profile/ProfilePage.test.tsx
+++ b/client/src/test/page/profile/ProfilePage.test.tsx
@@ -63,4 +63,19 @@ describe("ProfilePage", () => {
             expect(mockNavigate).toHaveBeenCalledWith("/logout");
         });
     });
+
+    it("'멤버로 전환' 버튼을 클릭하면 멤버로 전환 페이지로 이동한다", async () => {
+        // given
+        renderWithWrapper(<ProfilePage />);
+        const toMemberButton = await screen.findByTestId("to-member-button");
+        const user = userEvent.setup();
+
+        // when
+        await user.click(toMemberButton);
+
+        // then
+        await waitFor(() => {
+            expect(mockNavigate).toHaveBeenCalledWith("/profile/to-member");
+        });
+    });
 });

--- a/client/src/test/page/profile/ToMemberPage.test.tsx
+++ b/client/src/test/page/profile/ToMemberPage.test.tsx
@@ -1,0 +1,29 @@
+import { screen, waitFor } from "@testing-library/dom";
+import userEvent from "@testing-library/user-event";
+import { renderWithWrapper } from "../../utils/renderWithWrapper";
+import ToMemberPage from "../../../page/profile/ToMemberPage";
+
+vi.mock("react-router");
+
+describe("ToMemberPage", () => {
+    it('"GitHub으로 계속하기" 버튼을 클릭하면 GitHub 인증 페이지로 이동한다', async () => {
+        // given
+        const assignMock = vi.fn();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        delete (window as any).location;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (window as any).location = { assign: assignMock };
+
+        renderWithWrapper(<ToMemberPage />);
+        const gitHubButton = await screen.findByTestId("github-button");
+        const user = userEvent.setup();
+
+        // when
+        await user.click(gitHubButton);
+
+        // then
+        await waitFor(() => {
+            expect(assignMock).toHaveBeenCalled();
+        });
+    });
+});


### PR DESCRIPTION
## 관련 이슈

- #136

## 변경 사항

- ToMemberPage를 생성하고, Profile 페이지에서 버튼으로 이동할 수 있도록 수정하였습니다.
- 기존 멤버를 promote하는 게 아닌 새 멤버를 만들도록(GUEST 멤버는 nickname 뿐이기 때문에) 우선 구현하였습니다.

## 고려 사항 및 주의 사항 (선택)

- 필요하면 기존 인증 정보를 가지고 멤버 생성 시에 사용할 수 있습니다.

## 추가 정보 (선택)
