### PR TITLE
[FEATURE #156]: 로그아웃 페이지 구현

### DIFF
--- a/client/src/api/auth.api.ts
+++ b/client/src/api/auth.api.ts
@@ -27,3 +27,7 @@ export const joinAsMemberByGitHub = async (
         )
     ).data;
 };
+
+export const logOut = async (): Promise<void> => {
+    return (await api.post("/auth/log-out")).data;
+};

--- a/client/src/page/auth/LogOutPage.tsx
+++ b/client/src/page/auth/LogOutPage.tsx
@@ -1,0 +1,25 @@
+import { useEffect } from "react";
+import { useAuthStore } from "../../store/useAuthStore";
+import { useNavigate } from "react-router";
+import { useMutation } from "@tanstack/react-query";
+import { logOut } from "../../api/auth.api";
+
+export default function LogOutPage() {
+    const { setAuthenticated } = useAuthStore();
+    const navigate = useNavigate();
+
+    const { mutate } = useMutation({
+        mutationFn: logOut,
+        onSuccess: () => {
+            setAuthenticated(false);
+            localStorage.removeItem("accessToken");
+            navigate("/landing");
+        },
+    });
+
+    useEffect(() => {
+        mutate();
+    }, [mutate]);
+
+    return <></>;
+}

--- a/client/src/test/page/auth/LogOutPage.test.tsx
+++ b/client/src/test/page/auth/LogOutPage.test.tsx
@@ -1,0 +1,56 @@
+import { waitFor } from "@testing-library/dom";
+import { mockNavigate } from "../../../../__mocks__/react-router";
+import { useAuthStore } from "../../../store/useAuthStore";
+import { renderWithWrapper } from "../../utils/renderWithWrapper";
+import LogOutPage from "../../../page/auth/LogOutPage";
+import { baseUrl, server } from "../../../mocks/server";
+import { http, HttpResponse } from "msw";
+
+vi.mock("react-router");
+vi.mock("zustand");
+
+describe("LogOutPage", () => {
+    beforeEach(() => {
+        server.use(
+            http.post(`${baseUrl}/auth/log-out`, () => HttpResponse.text("ok"))
+        );
+    });
+
+    it("마운트 시 useAuthStore의 현재 인증 정보를 지운다", async () => {
+        // given
+        const { isAuthenticated } = useAuthStore.getState();
+
+        // when
+        renderWithWrapper(<LogOutPage />);
+
+        // then
+        await waitFor(() => {
+            expect(isAuthenticated).toBeFalsy();
+            expect(mockNavigate).toHaveBeenCalledWith("/landing");
+        });
+    });
+
+    it("마운트 시 localStorage의 엑세스토큰을 삭제한다", async () => {
+        // given
+
+        // when
+        renderWithWrapper(<LogOutPage />);
+
+        // then
+        await waitFor(() => {
+            expect(localStorage.getItem("accessToken")).toBeNull();
+        });
+    });
+
+    it("로그아웃을 요청하고 성공 시 랜딩 페이지로 이동한다", async () => {
+        // given
+
+        // when
+        renderWithWrapper(<LogOutPage />);
+
+        // then
+        await waitFor(() => {
+            expect(mockNavigate).toHaveBeenCalledWith("/landing");
+        });
+    });
+});


### PR DESCRIPTION
## 관련 이슈

- #156 

## 변경 사항

- 아래 요구 사항을 만족하는 LogOutPage.tsx 와 테스트를 구현하였습니다.
  - 로그아웃을 요청하고 성공 시 랜딩 페이지로 이동한다
  - useAuthStore의 현재 인증 정보를 지운다
  - localStorage의 엑세스토큰을 삭제한다

## 고려 사항 및 주의 사항 (선택)

- `api/auth/log-out` API의 구현이 필요합니다.
- `useAuthStore`를 사용하는 다른 페이지에서 해당하는 테스트가 추가되어야 합니다.
- 멤버로 가입 로직에서 `useAuthStore`를 통해 인증 상태 업데이트가 필요합니다.

## 추가 정보 (선택)
